### PR TITLE
Spark dgx fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -128,3 +128,8 @@ Data/Pretrained
 Data/utils.py
 Experiment/checkpoint
 Experiment/log
+
+# waheedbrown@gmail.com testing
+DEBUG
+results
+waheed_models

--- a/=0.0.30
+++ b/=0.0.30
@@ -1,0 +1,6 @@
+Using pip 26.0.1 from /home/waheedbrown/miniconda3/envs/unifolm-wma/lib/python3.10/site-packages/pip (python 3.10)
+Collecting xformers
+  Downloading xformers-0.0.35.tar.gz (4.3 MB)
+     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 4.3/4.3 MB 29.5 MB/s  0:00:00
+  Preparing metadata (pyproject.toml): started
+  Preparing metadata (pyproject.toml): finished with status 'error'

--- a/SPARK_SETUP.md
+++ b/SPARK_SETUP.md
@@ -1,0 +1,87 @@
+# NVIDIA DGX Spark Setup & CUDA Fixes
+
+This document outlines the fixes and optimizations applied to run the UnifoLM-WMA-0 model on an **NVIDIA DGX Spark** with **Blackwell (GB10)** GPUs.
+
+## 1. CUDA & GPU Fixes
+
+### Problem: Broken Driver/Kernel Mismatch
+On the DGX Spark, `nvidia-smi` may fail with:
+`NVIDIA-SMI has failed because it couldn't communicate with the NVIDIA driver.`
+
+This occurs when the NVIDIA kernel module is not compiled for the current kernel (e.g., `6.14.0-1015-nvidia`).
+
+**Fix:**
+Ensure the driver is correctly installed and loaded for the active kernel.
+```bash
+sudo apt-get install --reinstall nvidia-driver-580
+# Or rebuild via DKMS
+sudo dkms autoinstall
+```
+
+### Problem: CPU-only PyTorch
+The default environment may have a CPU-only build of PyTorch.
+
+**Fix:**
+Force reinstall PyTorch with CUDA 13.0 support (required for Blackwell GPUs):
+```bash
+pip install --force-reinstall torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cu130
+```
+
+### Problem: Blackwell Compatibility Warning
+PyTorch may show a warning:
+`Found GPU0 NVIDIA GB10 which is of cuda capability 12.1. Minimum and Maximum cuda capability supported by this version of PyTorch is (8.0) - (12.0)`
+
+**Optimization:**
+Guide PyTorch to target the Blackwell architecture:
+```bash
+export TORCH_CUDA_ARCH_LIST="12.1"
+```
+
+## 2. Codebase Adaptations for Robustness
+
+Several hardcoded `cuda` calls and strict loading requirements were modified to allow for device-agnostic execution and loading of base models:
+
+- **Checkpoint Loading:** Updated `scripts/evaluation/world_model_interaction.py` to use `strict=False` in `load_state_dict`. This allows the base model (which lacks specific action/state heads) to load correctly.
+- **Device Agnostic Encoders:** Updated all encoders in `src/unifolm_wma/modules/encoders/condition.py` to check for CUDA availability instead of defaulting to `"cuda"`.
+- **Vision Backbone:** Updated `src/unifolm_wma/modules/vision/dinosiglip_vit.py` to move tensors to the device of the model parameters.
+- **Sampler Fix:** Fixed `src/unifolm_wma/models/samplers/ddim.py` to use `self.model.device` in `register_buffer`.
+- **Xformers Assertion:** Removed a hardcoded assertion in `src/unifolm_wma/modules/attention.py` that forced `xformers` usage, allowing a fallback to standard PyTorch attention.
+
+## 3. Performance Bottlenecks & Missing Wheels
+
+Performance is currently limited by the absence of specialized Blackwell (SM 12.1) binaries for libraries like `xformers`.
+
+### Missing: `xformers` for CUDA 13.0
+The standard `pip install xformers` fails for CUDA 13.0 because pre-built wheels are not yet available on the PyTorch index.
+
+### Performance Impact
+Without `xformers`, the model uses standard PyTorch attention. While functional, it is significantly slower than the optimized Memory Efficient Attention provided by `xformers`.
+
+## 4. Building Missing Wheels Manually
+
+To achieve peak performance on the DGX Spark, you must build `xformers` from source.
+
+### Requirements
+- CUDA Toolkit 13.0
+- `nvcc` in your PATH
+- `ninja` build system
+
+### Build Instructions
+```bash
+conda activate unifolm-wma
+pip install ninja
+git clone https://github.com/facebookresearch/xformers.git
+cd xformers
+git submodule update --init --recursive
+export TORCH_CUDA_ARCH_LIST="12.1"
+pip install -v -e .
+```
+*Note: The build process can take 30-60 minutes depending on CPU performance.*
+
+## 5. Running the Model
+
+Always ensure the correct environment and architecture list are set:
+```bash
+export TORCH_CUDA_ARCH_LIST="12.1"
+conda run -n unifolm-wma bash scripts/run_world_model_interaction.sh
+```

--- a/SPARK_SETUP.md
+++ b/SPARK_SETUP.md
@@ -37,17 +37,18 @@ Guide PyTorch to target the Blackwell architecture:
 export TORCH_CUDA_ARCH_LIST="12.1"
 ```
 
-## 2. Codebase Adaptations for Robustness
+## 3. Codebase Adaptations for Robustness
 
 Several hardcoded `cuda` calls and strict loading requirements were modified to allow for device-agnostic execution and loading of base models:
 
+- **Blackwell-Specific Attention:** Added a high-performance fallback for Blackwell GPUs (capability 12.0+). When `xformers` is unavailable or incompatible, the model now automatically uses PyTorch's `F.scaled_dot_product_attention` (SDPA) with `bfloat16` casting. This resolves the `NotImplementedError` previously seen on GB10 GPUs while maintaining peak performance.
+- **Video IO Compatibility:** Replaced all calls to `torchvision.io.write_video` with `imageio.mimsave`. This fixes an `AttributeError` on systems where the `torchvision` build lacks native video IO support (a common issue on custom aarch64/CUDA 13.0 environments).
 - **Checkpoint Loading:** Updated `scripts/evaluation/world_model_interaction.py` to use `strict=False` in `load_state_dict`. This allows the base model (which lacks specific action/state heads) to load correctly.
 - **Device Agnostic Encoders:** Updated all encoders in `src/unifolm_wma/modules/encoders/condition.py` to check for CUDA availability instead of defaulting to `"cuda"`.
 - **Vision Backbone:** Updated `src/unifolm_wma/modules/vision/dinosiglip_vit.py` to move tensors to the device of the model parameters.
 - **Sampler Fix:** Fixed `src/unifolm_wma/models/samplers/ddim.py` to use `self.model.device` in `register_buffer`.
-- **Xformers Assertion:** Removed a hardcoded assertion in `src/unifolm_wma/modules/attention.py` that forced `xformers` usage, allowing a fallback to standard PyTorch attention.
 
-## 3. Performance Bottlenecks & Missing Wheels
+## 4. Performance Bottlenecks & Missing Wheels
 
 Performance is currently limited by the absence of specialized Blackwell (SM 12.1) binaries for libraries like `xformers`.
 

--- a/configs/inference/world_model_interaction.yaml
+++ b/configs/inference/world_model_interaction.yaml
@@ -1,6 +1,7 @@
 model:
   target: unifolm_wma.models.ddpms.LatentVisualDiffusion
   params:
+    pretrained_checkpoint: '/home/waheedbrown/workspaces/git/unifolm-world-model-action/waheed_models/unifolm_wma_base.ckpt'
     rescale_betas_zero_snr: True
     parameterization: "v"
     linear_start: 0.00085
@@ -222,7 +223,7 @@ data:
     test:
       target: unifolm_wma.data.wma_data.WMAData
       params:
-        data_dir: '/path/to/unifolm-world-model-action/examples/world_model_interaction_prompts'
+        data_dir: '/home/waheedbrown/workspaces/git/unifolm-world-model-action/examples/world_model_interaction_prompts'
         video_length: ${model.params.wma_config.params.temporal_length}
         frame_stride: 2
         load_raw_resolution: True

--- a/inspect_ckpt.py
+++ b/inspect_ckpt.py
@@ -1,0 +1,21 @@
+import torch
+ckpt_path = 'waheed_models/unifolm_wma_base.ckpt'
+sd = torch.load(ckpt_path, map_location='cpu')
+if 'state_dict' in sd:
+    sd = sd['state_dict']
+print("Number of keys:", len(sd.keys()))
+print("First 20 keys:")
+for k in list(sd.keys())[:20]:
+    print(k)
+
+missing_keys = [
+    "agent_action_pos_emb", "agent_state_pos_emb", "cond_pos_emb",
+    "model.diffusion_model.input_blocks.1.1.transformer_blocks.0.attn2.to_k_as.weight"
+]
+
+for mk in missing_keys:
+    print(f"Is '{mk}' in sd? {'Yes' if mk in sd else 'No'}")
+    # also check without 'model.' prefix
+    if mk.startswith('model.'):
+        mk_no_model = mk[6:]
+        print(f"Is '{mk_no_model}' in sd? {'Yes' if mk_no_model in sd else 'No'}")

--- a/pyproject.toml.bak
+++ b/pyproject.toml.bak
@@ -6,8 +6,7 @@ license = { text = "BSD-3-Clause" }
 authors = [
     {name="Unitree Embodied AI R&D Team", email="rd_xyc@unitree.com"  }
 ]
-#requires-python = "==3.10.18"
-requires-python = ">=3.10.18"
+requires-python = "==3.10.18"
 dependencies = [
     "decord==0.6.0",
     "einops==0.8.0",
@@ -26,7 +25,7 @@ dependencies = [
     "transformers==4.40.1",
     "moviepy==1.0.3",
     "av==12.3.0",
-    #"xformers==0.0.27",
+    "xformers==0.0.27",
     "gradio==4.39.0",
     "timm==0.9.10",
     "scikit-learn==1.5.1",
@@ -39,7 +38,7 @@ dependencies = [
     "tensorflow-metadata==1.16.1",
     "protobuf==3.20.3",
     "datasets==3.6.0",
-    #"tensorflow-graphics==2021.12.3",
+    "tensorflow-graphics==2021.12.3",
     "fairscale==0.4.13"
 ]
 

--- a/scripts/evaluation/base_model_inference.py
+++ b/scripts/evaluation/base_model_inference.py
@@ -4,7 +4,8 @@ import pandas as pd
 import torch
 import torchvision
 import torchvision.transforms as transforms
-import random
+import warnings
+import imageio
 
 from pytorch_lightning import seed_everything
 from PIL import Image
@@ -224,11 +225,7 @@ def save_results_seperate(prompt: str | list[str],
             grid = (grid + 1.0) / 2.0
             grid = (grid * 255).to(torch.uint8).permute(1, 2, 3, 0)
             path = os.path.join(savedirs[idx], f'{filename.split(".")[0]}.mp4')
-            torchvision.io.write_video(path,
-                                       grid,
-                                       fps=fps,
-                                       video_codec='h264',
-                                       options={'crf': '0'})
+            imageio.mimsave(path, list(grid.numpy()), fps=fps)
 
 
 def get_latent_z(model: torch.nn.Module, videos: torch.Tensor) -> torch.Tensor:

--- a/scripts/evaluation/real_eval_server.py
+++ b/scripts/evaluation/real_eval_server.py
@@ -107,11 +107,7 @@ def save_results(video: torch.Tensor, filename: str, fps: int = 8) -> None:
     grid = torch.stack(frame_grids, dim=0)
     grid = (grid + 1.0) / 2.0
     grid = (grid * 255).to(torch.uint8).permute(0, 2, 3, 1)
-    torchvision.io.write_video(filename,
-                               grid,
-                               fps=fps,
-                               video_codec='h264',
-                               options={'crf': '10'})
+    imageio.mimsave(filename, list(grid.numpy()), fps=fps)
 
 
 def get_latent_z(model: nn.Module, videos: torch.Tensor) -> torch.Tensor:

--- a/scripts/evaluation/world_model_interaction.py
+++ b/scripts/evaluation/world_model_interaction.py
@@ -87,7 +87,7 @@ def load_model_checkpoint(model: nn.Module, ckpt: str) -> nn.Module:
     if "state_dict" in list(state_dict.keys()):
         state_dict = state_dict["state_dict"]
         try:
-            model.load_state_dict(state_dict, strict=True)
+            model.load_state_dict(state_dict, strict=False)
         except:
             new_pl_sd = OrderedDict()
             for k, v in state_dict.items():
@@ -98,12 +98,12 @@ def load_model_checkpoint(model: nn.Module, ckpt: str) -> nn.Module:
                     new_key = k.replace("framestride_embed", "fps_embedding")
                     new_pl_sd[new_key] = new_pl_sd[k]
                     del new_pl_sd[k]
-            model.load_state_dict(new_pl_sd, strict=True)
+            model.load_state_dict(new_pl_sd, strict=False)
     else:
         new_pl_sd = OrderedDict()
         for key in state_dict['module'].keys():
             new_pl_sd[key[16:]] = state_dict['module'][key]
-        model.load_state_dict(new_pl_sd)
+        model.load_state_dict(new_pl_sd, strict=False)
     print('>>> model checkpoint loaded.')
     return model
 
@@ -470,7 +470,10 @@ def run_inference(args: argparse.Namespace, gpu_num: int, gpu_no: int) -> None:
     data.setup()
     print(">>> Dataset is successfully loaded ...")
 
-    model = model.cuda(gpu_no)
+    if torch.cuda.is_available():
+        model = model.cuda(gpu_no)
+    else:
+        print(">>> CUDA is not available, falling back to CPU. (Note: this may be VERY slow)")
     device = get_device_from_parameters(model)
 
     # Run over data

--- a/scripts/evaluation/world_model_interaction.py
+++ b/scripts/evaluation/world_model_interaction.py
@@ -143,11 +143,7 @@ def save_results(video: Tensor, filename: str, fps: int = 8) -> None:
     grid = torch.stack(frame_grids, dim=0)
     grid = (grid + 1.0) / 2.0
     grid = (grid * 255).to(torch.uint8).permute(0, 2, 3, 1)
-    torchvision.io.write_video(filename,
-                               grid,
-                               fps=fps,
-                               video_codec='h264',
-                               options={'crf': '10'})
+    imageio.mimsave(filename, list(grid.numpy()), fps=fps)
 
 
 def get_init_frame_path(data_dir: str, sample: dict) -> str:

--- a/scripts/run_world_model_interaction.sh
+++ b/scripts/run_world_model_interaction.sh
@@ -1,8 +1,8 @@
 model_name=testing
-ckpt=/path/to/model/checkpoint
+ckpt=/home/waheedbrown/workspaces/git/unifolm-world-model-action/waheed_models/unifolm_wma_base.ckpt
 config=configs/inference/world_model_interaction.yaml
 seed=123
-res_dir="/path/to/result/directory"
+res_dir="/home/waheedbrown/workspaces/git/unifolm-world-model-action/results"
 
 datasets=(
     "unitree_z1_stackbox"
@@ -29,7 +29,7 @@ for i in "${!datasets[@]}"; do
     --unconditional_guidance_scale 1.0 \
     --ddim_steps 50 \
     --ddim_eta 1.0 \
-    --prompt_dir "/path/to/unifolm-world-model-action/examples/world_model_interaction_prompts" \
+    --prompt_dir "/home/waheedbrown/workspaces/git/unifolm-world-model-action/examples/world_model_interaction_prompts" \
     --dataset ${dataset} \
     --video_length 16 \
     --frame_stride ${fs} \

--- a/src/unifolm_wma/models/diffusion_head/conditional_unet1d.py
+++ b/src/unifolm_wma/models/diffusion_head/conditional_unet1d.py
@@ -1,6 +1,7 @@
 import logging
 import torch
 import torch.nn as nn
+import torch.nn.functional as F
 import einops
 
 from einops import rearrange, repeat
@@ -90,12 +91,25 @@ class CrossAttention(nn.Module):
                     b * self.heads, t.shape[1], self.dim_head).contiguous(),
             (q, k, v),
         )
+
+        # NVIDIA DGX Spark CUDA 12.1 xformers compatibility
+        orig_dtype = q.dtype
+        q, k, v = q.to(torch.bfloat16), k.to(torch.bfloat16), v.to(torch.bfloat16)
+
         # actually compute the attention, what we cannot get enough of
-        out = xformers.ops.memory_efficient_attention(q,
-                                                      k,
-                                                      v,
-                                                      attn_bias=None,
-                                                      op=None)
+        if q.is_cuda and torch.cuda.get_device_capability(q.device)[0] >= 12:
+            out = F.scaled_dot_product_attention(q.unsqueeze(1),
+                                                 k.unsqueeze(1),
+                                                 v.unsqueeze(1),
+                                                 attn_mask=None).squeeze(1)
+        else:
+            out = xformers.ops.memory_efficient_attention(q,
+                                                          k,
+                                                          v,
+                                                          attn_bias=None,
+                                                          op=None)
+        
+        out = out.to(orig_dtype)
         out = (out.unsqueeze(0).reshape(
             b, self.heads, out.shape[1],
             self.dim_head).permute(0, 2, 1,

--- a/src/unifolm_wma/models/samplers/ddim.py
+++ b/src/unifolm_wma/models/samplers/ddim.py
@@ -19,8 +19,8 @@ class DDIMSampler(object):
 
     def register_buffer(self, name, attr):
         if type(attr) == torch.Tensor:
-            if attr.device != torch.device("cuda"):
-                attr = attr.to(torch.device("cuda"))
+            if attr.device != self.model.device:
+                attr = attr.to(self.model.device)
         setattr(self, name, attr)
 
     def make_schedule(self,

--- a/src/unifolm_wma/modules/attention.py
+++ b/src/unifolm_wma/modules/attention.py
@@ -125,7 +125,6 @@ class CrossAttention(nn.Module):
         context = default(context, x)
 
         if self.image_cross_attention and not spatial_self_attn:
-            assert 1 > 2, ">>> ERROR: should setup xformers and use efficient_forward ..."
             context_agent_state = context[:, :self.agent_state_context_len, :]
             context_agent_action = context[:,
                                            self.agent_state_context_len:self.

--- a/src/unifolm_wma/modules/attention.py
+++ b/src/unifolm_wma/modules/attention.py
@@ -291,11 +291,28 @@ class CrossAttention(nn.Module):
                         b * self.heads, t.shape[1], self.dim_head).contiguous(),
                 (k, v),
             )
-            out = xformers.ops.memory_efficient_attention(q,
-                                                          k,
-                                                          v,
-                                                          attn_bias=None,
-                                                          op=None)
+
+            # NVIDIA DGX Spark CUDA 12.1 xformers compatibility
+            # 1. Save original dtype and cast to bfloat16 for Blackwell
+            orig_dtype = q.dtype
+            q, k, v = q.to(torch.bfloat16), k.to(torch.bfloat16), v.to(torch.bfloat16)
+
+            # 2. Use the existing xformers call
+            if q.is_cuda and torch.cuda.get_device_capability(q.device)[0] >= 12:
+                out = F.scaled_dot_product_attention(q.unsqueeze(1),
+                                                     k.unsqueeze(1),
+                                                     v.unsqueeze(1),
+                                                     attn_mask=None).squeeze(1)
+            else:
+                out = xformers.ops.memory_efficient_attention(q,
+                                                              k,
+                                                              v,
+                                                              attn_bias=None,
+                                                              op=None)
+            
+            # 3. Cast the output back to prevent downstream type mismatches
+            out = out.to(orig_dtype)
+
             out = (out.unsqueeze(0).reshape(
                 b, self.heads, out.shape[1],
                 self.dim_head).permute(0, 2, 1,
@@ -311,11 +328,27 @@ class CrossAttention(nn.Module):
                         ),
                 (k_ip, v_ip),
             )
-            out_ip = xformers.ops.memory_efficient_attention(q,
-                                                             k_ip,
-                                                             v_ip,
-                                                             attn_bias=None,
-                                                             op=None)
+
+            # NVIDIA DGX Spark CUDA 12.1 xformers compatibility
+            # Query/Key/Value all need the same dtype
+            # 1. Cast k and v to bfloat16
+            k_ip, v_ip = k_ip.to(torch.bfloat16), v_ip.to(torch.bfloat16)
+
+            if q.is_cuda and torch.cuda.get_device_capability(q.device)[0] >= 12:
+                out_ip = F.scaled_dot_product_attention(q.unsqueeze(1),
+                                                         k_ip.unsqueeze(1),
+                                                         v_ip.unsqueeze(1),
+                                                         attn_mask=None).squeeze(1)
+            else:
+                out_ip = xformers.ops.memory_efficient_attention(q,
+                                                                 k_ip,
+                                                                 v_ip,
+                                                                 attn_bias=None,
+                                                                 op=None)
+            
+            # 2. Cast output back to float32
+            out_ip = out_ip.to(orig_dtype)
+
             out_ip = (out_ip.unsqueeze(0).reshape(
                 b, self.heads, out_ip.shape[1],
                 self.dim_head).permute(0, 2, 1,
@@ -331,11 +364,27 @@ class CrossAttention(nn.Module):
                         ),
                 (k_as, v_as),
             )
-            out_as = xformers.ops.memory_efficient_attention(q,
-                                                             k_as,
-                                                             v_as,
-                                                             attn_bias=None,
-                                                             op=None)
+
+            # NVIDIA DGX Spark CUDA 12.1 xformers compatibility
+            # Query/Key/Value all need the same dtype
+            # 1. Cast k and v to bfloat16
+            k_as, v_as = k_as.to(torch.bfloat16), v_as.to(torch.bfloat16)
+
+            if q.is_cuda and torch.cuda.get_device_capability(q.device)[0] >= 12:
+                out_as = F.scaled_dot_product_attention(q.unsqueeze(1),
+                                                         k_as.unsqueeze(1),
+                                                         v_as.unsqueeze(1),
+                                                         attn_mask=None).squeeze(1)
+            else:
+                out_as = xformers.ops.memory_efficient_attention(q,
+                                                                 k_as,
+                                                                 v_as,
+                                                                 attn_bias=None,
+                                                                 op=None)
+            
+            # 2. Cast output back to float32
+            out_as = out_as.to(orig_dtype)
+
             out_as = (out_as.unsqueeze(0).reshape(
                 b, self.heads, out_as.shape[1],
                 self.dim_head).permute(0, 2, 1,
@@ -353,10 +402,26 @@ class CrossAttention(nn.Module):
 
             attn_mask_aa = attn_mask_aa.unsqueeze(1).repeat(1,self.heads,1,1).reshape(
                     b * self.heads, attn_mask_aa.shape[1], attn_mask_aa.shape[2])
-            attn_mask_aa = attn_mask_aa.to(q.dtype)
+            
+            # NVIDIA DGX Spark CUDA 12.1 xformers compatibility
+            # Query/Key/Value all need the same dtype
+            # 1. Cast k and v to bfloat16
+            k_aa, v_aa = k_aa.to(torch.bfloat16), v_aa.to(torch.bfloat16)
 
-            out_aa = xformers.ops.memory_efficient_attention(
-                q, k_aa, v_aa, attn_bias=attn_mask_aa, op=None)
+            # 2. The mask needs to match the cast type
+            attn_mask_aa = attn_mask_aa.to(torch.bfloat16)
+
+            if q.is_cuda and torch.cuda.get_device_capability(q.device)[0] >= 12:
+                out_aa = F.scaled_dot_product_attention(q.unsqueeze(1),
+                                                         k_aa.unsqueeze(1),
+                                                         v_aa.unsqueeze(1),
+                                                         attn_mask=attn_mask_aa.unsqueeze(1)).squeeze(1)
+            else:
+                out_aa = xformers.ops.memory_efficient_attention(
+                    q, k_aa, v_aa, attn_bias=attn_mask_aa, op=None)
+
+            # 3. Cast output back to float32
+            out_aa = out_aa.to(orig_dtype)
 
             out_aa = (out_aa.unsqueeze(0).reshape(
                 b, self.heads, out_aa.shape[1],

--- a/src/unifolm_wma/modules/encoders/condition.py
+++ b/src/unifolm_wma/modules/encoders/condition.py
@@ -49,7 +49,9 @@ class ClassEmbedder(nn.Module):
         c = self.embedding(c)
         return c
 
-    def get_unconditional_conditioning(self, bs, device="cuda"):
+    def get_unconditional_conditioning(self, bs, device=None):
+        if device is None:
+            device = "cuda" if torch.cuda.is_available() else "cpu"
         uc_class = self.n_classes - 1  # 1000 classes --> 0 ... 999, one extra class for ucg (class 1000)
         uc = torch.ones((bs, ), device=device) * uc_class
         uc = {self.key: uc}
@@ -67,7 +69,7 @@ class FrozenT5Embedder(AbstractEncoder):
 
     def __init__(self,
                  version="google/t5-v1_1-xxl",
-                 device="cuda",
+                 device='cuda' if torch.cuda.is_available() else 'cpu',
                  max_length=77,
                  freeze=True
                  ):  # others are google/t5-v1_1-xl and google/t5-v1_1-xxl
@@ -109,7 +111,7 @@ class FrozenCLIPEmbedder(AbstractEncoder):
 
     def __init__(self,
                  version="openai/clip-vit-large-patch14",
-                 device="cuda",
+                 device='cuda' if torch.cuda.is_available() else 'cpu',
                  max_length=77,
                  freeze=True,
                  layer="last",
@@ -215,7 +217,7 @@ class FrozenOpenCLIPEmbedder(AbstractEncoder):
     def __init__(self,
                  arch="ViT-H-14",
                  version="laion2b_s32b_b79k",
-                 device="cuda",
+                 device='cuda' if torch.cuda.is_available() else 'cpu',
                  max_length=77,
                  freeze=True,
                  layer="last"):
@@ -281,7 +283,7 @@ class FrozenOpenCLIPImageEmbedder(AbstractEncoder):
     def __init__(self,
                  arch="ViT-H-14",
                  version="laion2b_s32b_b79k",
-                 device="cuda",
+                 device='cuda' if torch.cuda.is_available() else 'cpu',
                  max_length=77,
                  freeze=True,
                  layer="pooled",
@@ -358,7 +360,7 @@ class FrozenOpenCLIPImageEmbedderV2(AbstractEncoder):
     def __init__(self,
                  arch="ViT-H-14",
                  version="laion2b_s32b_b79k",
-                 device="cuda",
+                 device='cuda' if torch.cuda.is_available() else 'cpu',
                  freeze=True,
                  layer="pooled",
                  antialias=True):
@@ -457,7 +459,7 @@ class FrozenCLIPT5Encoder(AbstractEncoder):
     def __init__(self,
                  clip_version="openai/clip-vit-large-patch14",
                  t5_version="google/t5-v1_1-xl",
-                 device="cuda",
+                 device='cuda' if torch.cuda.is_available() else 'cpu',
                  clip_max_length=77,
                  t5_max_length=77):
         super().__init__()

--- a/src/unifolm_wma/modules/vision/dinosiglip_vit.py
+++ b/src/unifolm_wma/modules/vision/dinosiglip_vit.py
@@ -240,15 +240,11 @@ class DinoSigLIPViTBackbone(VisionBackbone):
         siglip_normalizer = Normalize(
             mean=torch.tensor([0.5000, 0.5000, 0.5000]),
             std=torch.tensor([0.5000, 0.5000, 0.5000]))
+        device = next(self.dino_featurizer.parameters()).device
         pixel_values = {
-            'dino': dino_normalizer(img),
-            'siglip': siglip_normalizer(img)
+            'dino': dino_normalizer(img).to(device),
+            'siglip': siglip_normalizer(img).to(device)
         }
-
-        if self.on_gpu:
-            pixel_values = {k: v.cuda() for k, v in pixel_values.items()}
-        elif next(self.dino_featurizer.parameters()).device.type != 'cpu':
-            self.on_gpu = True
         """Runs the transformed image/pixel tensors through each vision backbone, returning concatenated patches."""
         dino_patches = self.dino_featurizer(pixel_values["dino"])
         siglip_patches = self.siglip_featurizer(pixel_values["siglip"])

--- a/src/unifolm_wma/utils/save_video.py
+++ b/src/unifolm_wma/utils/save_video.py
@@ -2,6 +2,7 @@ import os
 import torch
 import numpy as np
 import torchvision
+import imageio
 
 from tqdm import tqdm
 from PIL import Image
@@ -28,11 +29,7 @@ def frames_to_mp4(frame_dir, output_path, fps):
 
     videos = read_first_n_frames(frame_dir, num_frames=None)
     videos = videos.mul(255).to(torch.uint8).permute(0, 2, 3, 1)
-    torchvision.io.write_video(output_path,
-                               videos,
-                               fps=fps,
-                               video_codec='h264',
-                               options={'crf': '10'})
+    imageio.mimsave(output_path, list(videos.numpy()), fps=fps)
 
 
 def tensor_to_mp4(video, savepath, fps, rescale=True, nrow=None):
@@ -52,13 +49,8 @@ def tensor_to_mp4(video, savepath, fps, rescale=True, nrow=None):
     grid = torch.clamp(grid.float(), -1., 1.)
     if rescale:
         grid = (grid + 1.0) / 2.0
-    grid = (grid * 255).to(torch.uint8).permute(
-        0, 2, 3, 1)
-    torchvision.io.write_video(savepath,
-                               grid,
-                               fps=fps,
-                               video_codec='h264',
-                               options={'crf': '10'})
+    grid = (grid * 255).to(torch.uint8).permute(0, 2, 3, 1)
+    imageio.mimsave(savepath, list(grid.numpy()), fps=fps)
 
 
 def tensor2videogrids(video, root, filename, fps, rescale=True, clamp=True):
@@ -81,11 +73,7 @@ def tensor2videogrids(video, root, filename, fps, rescale=True, clamp=True):
     grid = (grid * 255).to(torch.uint8).permute(
         0, 2, 3, 1)
     path = os.path.join(root, filename)
-    torchvision.io.write_video(path,
-                               grid,
-                               fps=fps,
-                               video_codec='h264',
-                               options={'crf': '10'})
+    imageio.mimsave(path, list(grid.numpy()), fps=fps)
 
 
 def log_local(batch_logs, save_dir, filename, save_fps=10, rescale=True):
@@ -129,11 +117,7 @@ def log_local(batch_logs, save_dir, filename, save_fps=10, rescale=True):
                 grid = (grid + 1.0) / 2.0
             grid = (grid * 255).to(torch.uint8).permute(0, 2, 3, 1)
             path = os.path.join(save_dir, "%s-%s.mp4" % (key, filename))
-            torchvision.io.write_video(path,
-                                       grid,
-                                       fps=save_fps,
-                                       video_codec='h264',
-                                       options={'crf': '10'})
+            imageio.mimsave(path, list(grid.numpy()), fps=save_fps)
 
             # Save frame sheet
             img = value
@@ -251,8 +235,4 @@ def npz_to_video_grid(data_path,
         os.makedirs(os.path.dirname(out_path), exist_ok=True)
     frame_grids = (torch.stack(frame_grids) * 255).to(torch.uint8).permute(
         0, 2, 3, 1)
-    torchvision.io.write_video(out_path,
-                               frame_grids,
-                               fps=fps,
-                               video_codec='h264',
-                               options={'crf': '10'})
+    imageio.mimsave(out_path, list(frame_grids.numpy()), fps=fps)


### PR DESCRIPTION
This fixes allow the the unifolm-world-model-action to do inference on a NVIDIA DGX Spark:
- Tested and confirmed that the "Inference under Interactive Simulation Mode" example works on a DGX Spark, with full GPU acceleration
- This is related to issue #41 