### PR TITLE
G1 + Brainco Revo2 hands: setup guide, CycloneDDS fix, LeRobot dataset conversion, DGX Spark support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -128,3 +128,8 @@ Data/Pretrained
 Data/utils.py
 Experiment/checkpoint
 Experiment/log
+
+# waheedbrown@gmail.com testing
+DEBUG
+results
+waheed_models

--- a/.gitignore
+++ b/.gitignore
@@ -132,4 +132,5 @@ Experiment/log
 # waheedbrown@gmail.com testing
 DEBUG
 results
+waheed_datasets
 waheed_models

--- a/=0.0.30
+++ b/=0.0.30
@@ -1,0 +1,6 @@
+Using pip 26.0.1 from /home/waheedbrown/miniconda3/envs/unifolm-wma/lib/python3.10/site-packages/pip (python 3.10)
+Collecting xformers
+  Downloading xformers-0.0.35.tar.gz (4.3 MB)
+     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 4.3/4.3 MB 29.5 MB/s  0:00:00
+  Preparing metadata (pyproject.toml): started
+  Preparing metadata (pyproject.toml): finished with status 'error'

--- a/SPARK_SETUP.md
+++ b/SPARK_SETUP.md
@@ -1,0 +1,87 @@
+# NVIDIA DGX Spark Setup & CUDA Fixes
+
+This document outlines the fixes and optimizations applied to run the UnifoLM-WMA-0 model on an **NVIDIA DGX Spark** with **Blackwell (GB10)** GPUs.
+
+## 1. CUDA & GPU Fixes
+
+### Problem: Broken Driver/Kernel Mismatch
+On the DGX Spark, `nvidia-smi` may fail with:
+`NVIDIA-SMI has failed because it couldn't communicate with the NVIDIA driver.`
+
+This occurs when the NVIDIA kernel module is not compiled for the current kernel (e.g., `6.14.0-1015-nvidia`).
+
+**Fix:**
+Ensure the driver is correctly installed and loaded for the active kernel.
+```bash
+sudo apt-get install --reinstall nvidia-driver-580
+# Or rebuild via DKMS
+sudo dkms autoinstall
+```
+
+### Problem: CPU-only PyTorch
+The default environment may have a CPU-only build of PyTorch.
+
+**Fix:**
+Force reinstall PyTorch with CUDA 13.0 support (required for Blackwell GPUs):
+```bash
+pip install --force-reinstall torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cu130
+```
+
+### Problem: Blackwell Compatibility Warning
+PyTorch may show a warning:
+`Found GPU0 NVIDIA GB10 which is of cuda capability 12.1. Minimum and Maximum cuda capability supported by this version of PyTorch is (8.0) - (12.0)`
+
+**Optimization:**
+Guide PyTorch to target the Blackwell architecture:
+```bash
+export TORCH_CUDA_ARCH_LIST="12.1"
+```
+
+## 2. Codebase Adaptations for Robustness
+
+Several hardcoded `cuda` calls and strict loading requirements were modified to allow for device-agnostic execution and loading of base models:
+
+- **Checkpoint Loading:** Updated `scripts/evaluation/world_model_interaction.py` to use `strict=False` in `load_state_dict`. This allows the base model (which lacks specific action/state heads) to load correctly.
+- **Device Agnostic Encoders:** Updated all encoders in `src/unifolm_wma/modules/encoders/condition.py` to check for CUDA availability instead of defaulting to `"cuda"`.
+- **Vision Backbone:** Updated `src/unifolm_wma/modules/vision/dinosiglip_vit.py` to move tensors to the device of the model parameters.
+- **Sampler Fix:** Fixed `src/unifolm_wma/models/samplers/ddim.py` to use `self.model.device` in `register_buffer`.
+- **Xformers Assertion:** Removed a hardcoded assertion in `src/unifolm_wma/modules/attention.py` that forced `xformers` usage, allowing a fallback to standard PyTorch attention.
+
+## 3. Performance Bottlenecks & Missing Wheels
+
+Performance is currently limited by the absence of specialized Blackwell (SM 12.1) binaries for libraries like `xformers`.
+
+### Missing: `xformers` for CUDA 13.0
+The standard `pip install xformers` fails for CUDA 13.0 because pre-built wheels are not yet available on the PyTorch index.
+
+### Performance Impact
+Without `xformers`, the model uses standard PyTorch attention. While functional, it is significantly slower than the optimized Memory Efficient Attention provided by `xformers`.
+
+## 4. Building Missing Wheels Manually
+
+To achieve peak performance on the DGX Spark, you must build `xformers` from source.
+
+### Requirements
+- CUDA Toolkit 13.0
+- `nvcc` in your PATH
+- `ninja` build system
+
+### Build Instructions
+```bash
+conda activate unifolm-wma
+pip install ninja
+git clone https://github.com/facebookresearch/xformers.git
+cd xformers
+git submodule update --init --recursive
+export TORCH_CUDA_ARCH_LIST="12.1"
+pip install -v -e .
+```
+*Note: The build process can take 30-60 minutes depending on CPU performance.*
+
+## 5. Running the Model
+
+Always ensure the correct environment and architecture list are set:
+```bash
+export TORCH_CUDA_ARCH_LIST="12.1"
+conda run -n unifolm-wma bash scripts/run_world_model_interaction.sh
+```

--- a/SPARK_SETUP.md
+++ b/SPARK_SETUP.md
@@ -37,17 +37,18 @@ Guide PyTorch to target the Blackwell architecture:
 export TORCH_CUDA_ARCH_LIST="12.1"
 ```
 
-## 2. Codebase Adaptations for Robustness
+## 3. Codebase Adaptations for Robustness
 
 Several hardcoded `cuda` calls and strict loading requirements were modified to allow for device-agnostic execution and loading of base models:
 
+- **Blackwell-Specific Attention:** Added a high-performance fallback for Blackwell GPUs (capability 12.0+). When `xformers` is unavailable or incompatible, the model now automatically uses PyTorch's `F.scaled_dot_product_attention` (SDPA) with `bfloat16` casting. This resolves the `NotImplementedError` previously seen on GB10 GPUs while maintaining peak performance.
+- **Video IO Compatibility:** Replaced all calls to `torchvision.io.write_video` with `imageio.mimsave`. This fixes an `AttributeError` on systems where the `torchvision` build lacks native video IO support (a common issue on custom aarch64/CUDA 13.0 environments).
 - **Checkpoint Loading:** Updated `scripts/evaluation/world_model_interaction.py` to use `strict=False` in `load_state_dict`. This allows the base model (which lacks specific action/state heads) to load correctly.
 - **Device Agnostic Encoders:** Updated all encoders in `src/unifolm_wma/modules/encoders/condition.py` to check for CUDA availability instead of defaulting to `"cuda"`.
 - **Vision Backbone:** Updated `src/unifolm_wma/modules/vision/dinosiglip_vit.py` to move tensors to the device of the model parameters.
 - **Sampler Fix:** Fixed `src/unifolm_wma/models/samplers/ddim.py` to use `self.model.device` in `register_buffer`.
-- **Xformers Assertion:** Removed a hardcoded assertion in `src/unifolm_wma/modules/attention.py` that forced `xformers` usage, allowing a fallback to standard PyTorch attention.
 
-## 3. Performance Bottlenecks & Missing Wheels
+## 4. Performance Bottlenecks & Missing Wheels
 
 Performance is currently limited by the absence of specialized Blackwell (SM 12.1) binaries for libraries like `xformers`.
 

--- a/configs/inference/world_model_decision_making.yaml
+++ b/configs/inference/world_model_decision_making.yaml
@@ -236,5 +236,5 @@ data:
         n_obs_steps: ${model.params.n_obs_steps_imagen}
         max_action_dim: ${model.params.agent_action_dim}
         max_state_dim: ${model.params.agent_state_dim}
-    dataset_and_weights: 
+    dataset_and_weights:
       unitree_g1_pack_camera: 1.0

--- a/configs/inference/world_model_interaction.yaml
+++ b/configs/inference/world_model_interaction.yaml
@@ -1,6 +1,7 @@
 model:
   target: unifolm_wma.models.ddpms.LatentVisualDiffusion
   params:
+    pretrained_checkpoint: '/home/waheedbrown/workspaces/git/unifolm-world-model-action/waheed_models/unifolm_wma_base.ckpt'
     rescale_betas_zero_snr: True
     parameterization: "v"
     linear_start: 0.00085
@@ -222,7 +223,7 @@ data:
     test:
       target: unifolm_wma.data.wma_data.WMAData
       params:
-        data_dir: '/path/to/unifolm-world-model-action/examples/world_model_interaction_prompts'
+        data_dir: '/home/waheedbrown/workspaces/git/unifolm-world-model-action/examples/world_model_interaction_prompts'
         video_length: ${model.params.wma_config.params.temporal_length}
         frame_stride: 2
         load_raw_resolution: True

--- a/inspect_ckpt.py
+++ b/inspect_ckpt.py
@@ -1,0 +1,21 @@
+import torch
+ckpt_path = 'waheed_models/unifolm_wma_base.ckpt'
+sd = torch.load(ckpt_path, map_location='cpu')
+if 'state_dict' in sd:
+    sd = sd['state_dict']
+print("Number of keys:", len(sd.keys()))
+print("First 20 keys:")
+for k in list(sd.keys())[:20]:
+    print(k)
+
+missing_keys = [
+    "agent_action_pos_emb", "agent_state_pos_emb", "cond_pos_emb",
+    "model.diffusion_model.input_blocks.1.1.transformer_blocks.0.attn2.to_k_as.weight"
+]
+
+for mk in missing_keys:
+    print(f"Is '{mk}' in sd? {'Yes' if mk in sd else 'No'}")
+    # also check without 'model.' prefix
+    if mk.startswith('model.'):
+        mk_no_model = mk[6:]
+        print(f"Is '{mk_no_model}' in sd? {'Yes' if mk_no_model in sd else 'No'}")

--- a/pyproject.toml.bak
+++ b/pyproject.toml.bak
@@ -6,8 +6,7 @@ license = { text = "BSD-3-Clause" }
 authors = [
     {name="Unitree Embodied AI R&D Team", email="rd_xyc@unitree.com"  }
 ]
-#requires-python = "==3.10.18"
-requires-python = ">=3.10.18"
+requires-python = "==3.10.18"
 dependencies = [
     "decord==0.6.0",
     "einops==0.8.0",
@@ -26,7 +25,7 @@ dependencies = [
     "transformers==4.40.1",
     "moviepy==1.0.3",
     "av==12.3.0",
-    #"xformers==0.0.27",
+    "xformers==0.0.27",
     "gradio==4.39.0",
     "timm==0.9.10",
     "scikit-learn==1.5.1",
@@ -39,7 +38,7 @@ dependencies = [
     "tensorflow-metadata==1.16.1",
     "protobuf==3.20.3",
     "datasets==3.6.0",
-    #"tensorflow-graphics==2021.12.3",
+    "tensorflow-graphics==2021.12.3",
     "fairscale==0.4.13"
 ]
 

--- a/scripts/evaluation/base_model_inference.py
+++ b/scripts/evaluation/base_model_inference.py
@@ -4,7 +4,8 @@ import pandas as pd
 import torch
 import torchvision
 import torchvision.transforms as transforms
-import random
+import warnings
+import imageio
 
 from pytorch_lightning import seed_everything
 from PIL import Image
@@ -224,11 +225,7 @@ def save_results_seperate(prompt: str | list[str],
             grid = (grid + 1.0) / 2.0
             grid = (grid * 255).to(torch.uint8).permute(1, 2, 3, 0)
             path = os.path.join(savedirs[idx], f'{filename.split(".")[0]}.mp4')
-            torchvision.io.write_video(path,
-                                       grid,
-                                       fps=fps,
-                                       video_codec='h264',
-                                       options={'crf': '0'})
+            imageio.mimsave(path, list(grid.numpy()), fps=fps)
 
 
 def get_latent_z(model: torch.nn.Module, videos: torch.Tensor) -> torch.Tensor:

--- a/scripts/evaluation/real_eval_server.py
+++ b/scripts/evaluation/real_eval_server.py
@@ -107,11 +107,7 @@ def save_results(video: torch.Tensor, filename: str, fps: int = 8) -> None:
     grid = torch.stack(frame_grids, dim=0)
     grid = (grid + 1.0) / 2.0
     grid = (grid * 255).to(torch.uint8).permute(0, 2, 3, 1)
-    torchvision.io.write_video(filename,
-                               grid,
-                               fps=fps,
-                               video_codec='h264',
-                               options={'crf': '10'})
+    imageio.mimsave(filename, list(grid.numpy()), fps=fps)
 
 
 def get_latent_z(model: nn.Module, videos: torch.Tensor) -> torch.Tensor:

--- a/scripts/evaluation/real_eval_server.py
+++ b/scripts/evaluation/real_eval_server.py
@@ -439,7 +439,7 @@ class Server:
                 "de-normalizing the output actions.")
             return {'result': 'error', 'desc': traceback.format_exc()}
 
-    def run(self, host: str = "127.0.0.1", port: int = 8000) -> None:
+    def run(self, host: str = "0.0.0.0", port: int = 8000) -> None:
         self.app = FastAPI()
         self.app.post("/predict_action")(self.predict_action)
         print(">>> Inference server is ready ... ")
@@ -450,10 +450,14 @@ class Server:
 
 if __name__ == '__main__':
     parser = get_parser()
+    parser.add_argument("--host", type=str, default="0.0.0.0",
+                        help="Host address for the inference server.")
+    parser.add_argument("--port", type=int, default=8000,
+                        help="Port for the inference server.")
     args = parser.parse_args()
     seed = args.seed
     seed_everything(seed)
     rank, gpu_num = 0, 1
     print(">>> Launch inference server ... ")
     server = Server(args)
-    server.run()
+    server.run(host=args.host, port=args.port)

--- a/scripts/evaluation/world_model_interaction.py
+++ b/scripts/evaluation/world_model_interaction.py
@@ -87,7 +87,7 @@ def load_model_checkpoint(model: nn.Module, ckpt: str) -> nn.Module:
     if "state_dict" in list(state_dict.keys()):
         state_dict = state_dict["state_dict"]
         try:
-            model.load_state_dict(state_dict, strict=True)
+            model.load_state_dict(state_dict, strict=False)
         except:
             new_pl_sd = OrderedDict()
             for k, v in state_dict.items():
@@ -98,12 +98,12 @@ def load_model_checkpoint(model: nn.Module, ckpt: str) -> nn.Module:
                     new_key = k.replace("framestride_embed", "fps_embedding")
                     new_pl_sd[new_key] = new_pl_sd[k]
                     del new_pl_sd[k]
-            model.load_state_dict(new_pl_sd, strict=True)
+            model.load_state_dict(new_pl_sd, strict=False)
     else:
         new_pl_sd = OrderedDict()
         for key in state_dict['module'].keys():
             new_pl_sd[key[16:]] = state_dict['module'][key]
-        model.load_state_dict(new_pl_sd)
+        model.load_state_dict(new_pl_sd, strict=False)
     print('>>> model checkpoint loaded.')
     return model
 
@@ -470,7 +470,10 @@ def run_inference(args: argparse.Namespace, gpu_num: int, gpu_no: int) -> None:
     data.setup()
     print(">>> Dataset is successfully loaded ...")
 
-    model = model.cuda(gpu_no)
+    if torch.cuda.is_available():
+        model = model.cuda(gpu_no)
+    else:
+        print(">>> CUDA is not available, falling back to CPU. (Note: this may be VERY slow)")
     device = get_device_from_parameters(model)
 
     # Run over data

--- a/scripts/evaluation/world_model_interaction.py
+++ b/scripts/evaluation/world_model_interaction.py
@@ -143,11 +143,7 @@ def save_results(video: Tensor, filename: str, fps: int = 8) -> None:
     grid = torch.stack(frame_grids, dim=0)
     grid = (grid + 1.0) / 2.0
     grid = (grid * 255).to(torch.uint8).permute(0, 2, 3, 1)
-    torchvision.io.write_video(filename,
-                               grid,
-                               fps=fps,
-                               video_codec='h264',
-                               options={'crf': '10'})
+    imageio.mimsave(filename, list(grid.numpy()), fps=fps)
 
 
 def get_init_frame_path(data_dir: str, sample: dict) -> str:

--- a/scripts/prepare_lerobot_dataset.py
+++ b/scripts/prepare_lerobot_dataset.py
@@ -1,0 +1,229 @@
+#!/usr/bin/env python3
+"""
+Convert a LeRobot v3 dataset (G1_WBT_Brainco_Pickup_Pillow format) into the
+layout expected by unifolm-wma's WMAData loader.
+
+Required output structure under DATASET_DIR:
+    {dataset_name}.csv
+    videos/{dataset_name}/{episode_idx}.mp4   (symlinks to LeRobot videos)
+    transitions/{dataset_name}/{episode_idx}.h5
+    transitions/{dataset_name}/meta_data/stats.safetensors
+
+Usage:
+    python scripts/prepare_lerobot_dataset.py \
+        --dataset_dir /path/to/G1_WBT_Brainco_Pickup_Pillow/snapshot \
+        --dataset_name G1_WBT_Brainco_Pickup_Pillow \
+        --camera_key observation.images.head_stereo_left
+"""
+
+import argparse
+import json
+import os
+from pathlib import Path
+
+import h5py
+import numpy as np
+import pandas as pd
+import torch
+from safetensors.torch import save_file
+
+
+def parse_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--dataset_dir",
+        type=str,
+        required=True,
+        help="Path to the LeRobot dataset snapshot directory.",
+    )
+    parser.add_argument(
+        "--dataset_name",
+        type=str,
+        default="G1_WBT_Brainco_Pickup_Pillow",
+        help="Name of the dataset (used for directory/file naming).",
+    )
+    parser.add_argument(
+        "--camera_key",
+        type=str,
+        default="observation.images.head_stereo_left",
+        help="Which camera stream to use for the world-model video.",
+    )
+    parser.add_argument(
+        "--action_key",
+        type=str,
+        default="action.ee_action",
+        help="Column in parquet to use as the action vector.",
+    )
+    parser.add_argument(
+        "--state_key",
+        type=str,
+        default="observation.state.ee_state",
+        help="Column in parquet to use as the observation state vector.",
+    )
+    parser.add_argument(
+        "--instruction",
+        type=str,
+        default="Pick up the pillow and place it on the sofa",
+        help="Language instruction for all episodes.",
+    )
+    return parser.parse_args()
+
+
+def make_csv(dataset_dir: Path, dataset_name: str, num_episodes: int, instruction: str):
+    rows = []
+    for i in range(num_episodes):
+        rows.append({
+            "data_dir": dataset_name,
+            "videoid": str(i),
+            "instruction": instruction,
+            "embodiment": "x",
+        })
+    df = pd.DataFrame(rows)
+    csv_path = dataset_dir / f"{dataset_name}.csv"
+    df.to_csv(csv_path, index=False)
+    print(f"[CSV] Written {len(df)} rows → {csv_path}")
+
+
+def make_video_clips(dataset_dir: Path, dataset_name: str, episodes_df: pd.DataFrame, camera_key: str):
+    """Extract per-episode video clips from the concatenated LeRobot video files."""
+    import subprocess
+
+    video_out_dir = dataset_dir / "videos" / dataset_name
+    video_out_dir.mkdir(parents=True, exist_ok=True)
+
+    for _, row in episodes_df.iterrows():
+        ep_idx = int(row["episode_index"])
+        chunk_idx = int(row[f"videos/{camera_key}/chunk_index"])
+        file_idx = int(row[f"videos/{camera_key}/file_index"])
+        t_start = float(row[f"videos/{camera_key}/from_timestamp"])
+        t_end = float(row[f"videos/{camera_key}/to_timestamp"])
+        duration = t_end - t_start
+
+        src = (
+            dataset_dir
+            / "videos"
+            / camera_key
+            / f"chunk-{chunk_idx:03d}"
+            / f"file-{file_idx:03d}.mp4"
+        )
+        dst = video_out_dir / f"{ep_idx}.mp4"
+
+        if dst.exists():
+            continue
+
+        # Use ffmpeg to trim the clip; -c copy for fast remux if codec compatible,
+        # fall back to re-encode with libx264 for broad decord compatibility.
+        cmd = [
+            "ffmpeg", "-y",
+            "-ss", f"{t_start:.6f}",
+            "-t", f"{duration:.6f}",
+            "-i", str(src),
+            "-c:v", "libx264", "-preset", "ultrafast", "-crf", "18",
+            "-an",
+            str(dst),
+        ]
+        result = subprocess.run(cmd, capture_output=True)
+        if result.returncode != 0:
+            print(f"  [WARN] ffmpeg failed for episode {ep_idx}: {result.stderr.decode()[-200:]}")
+
+        if ep_idx % 20 == 0:
+            print(f"  episode {ep_idx}/{len(episodes_df)} ...")
+
+    print(f"[Video] Extracted {len(episodes_df)} clips to {video_out_dir}")
+
+
+def make_h5_files(
+    dataset_dir: Path,
+    dataset_name: str,
+    episodes_df: pd.DataFrame,
+    data_df: pd.DataFrame,
+    action_key: str,
+    state_key: str,
+):
+    out_dir = dataset_dir / "transitions" / dataset_name
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    for _, row in episodes_df.iterrows():
+        ep_idx = int(row["episode_index"])
+        from_idx = int(row["dataset_from_index"])
+        to_idx = int(row["dataset_to_index"])
+
+        ep_data = data_df.iloc[from_idx:to_idx]
+
+        actions = np.stack(ep_data[action_key].values).astype(np.float32)
+        states = np.stack(ep_data[state_key].values).astype(np.float32)
+
+        h5_path = out_dir / f"{ep_idx}.h5"
+        with h5py.File(h5_path, "w") as f:
+            f.create_dataset("action", data=actions)
+            f.create_dataset("observation.state", data=states)
+            f.attrs["action_type"] = action_key
+            f.attrs["state_type"] = state_key
+
+    print(f"[H5] Written {len(episodes_df)} HDF5 files to {out_dir}")
+
+
+def make_stats_safetensors(dataset_dir: Path, dataset_name: str, action_key: str, state_key: str):
+    stats_json_path = dataset_dir / "meta" / "stats.json"
+    with open(stats_json_path) as f:
+        stats_json = json.load(f)
+
+    meta_dir = dataset_dir / "transitions" / dataset_name / "meta_data"
+    meta_dir.mkdir(parents=True, exist_ok=True)
+
+    tensors = {}
+    for stat_field in ("min", "max", "mean", "std"):
+        tensors[f"action/{stat_field}"] = torch.tensor(
+            stats_json[action_key][stat_field], dtype=torch.float32
+        )
+        tensors[f"observation.state/{stat_field}"] = torch.tensor(
+            stats_json[state_key][stat_field], dtype=torch.float32
+        )
+
+    out_path = meta_dir / "stats.safetensors"
+    save_file(tensors, str(out_path))
+    print(f"[Stats] Written stats.safetensors → {out_path}")
+    print(f"        action/{{}}: shape {tensors['action/max'].shape}")
+    print(f"        observation.state/{{}}: shape {tensors['observation.state/max'].shape}")
+
+
+def main():
+    args = parse_args()
+    dataset_dir = Path(args.dataset_dir)
+
+    print(f"Dataset dir : {dataset_dir}")
+    print(f"Dataset name: {args.dataset_name}")
+    print(f"Camera key  : {args.camera_key}")
+    print(f"Action key  : {args.action_key}")
+    print(f"State key   : {args.state_key}")
+
+    # Load episodes metadata
+    episodes_df = pd.read_parquet(dataset_dir / "meta" / "episodes")
+    num_episodes = len(episodes_df)
+    print(f"\nFound {num_episodes} episodes.")
+
+    # Load full frame data (all chunks/files)
+    data_parts = []
+    for chunk_dir in sorted((dataset_dir / "data").iterdir()):
+        for parquet_file in sorted(chunk_dir.glob("*.parquet")):
+            data_parts.append(pd.read_parquet(parquet_file))
+    data_df = pd.concat(data_parts, ignore_index=True)
+    print(f"Loaded {len(data_df)} total frames from parquet.")
+
+    print("\n--- Generating CSV ---")
+    make_csv(dataset_dir, args.dataset_name, num_episodes, args.instruction)
+
+    print("\n--- Extracting per-episode video clips ---")
+    make_video_clips(dataset_dir, args.dataset_name, episodes_df, args.camera_key)
+
+    print("\n--- Creating H5 transition files ---")
+    make_h5_files(dataset_dir, args.dataset_name, episodes_df, data_df, args.action_key, args.state_key)
+
+    print("\n--- Creating stats.safetensors ---")
+    make_stats_safetensors(dataset_dir, args.dataset_name, args.action_key, args.state_key)
+
+    print("\nDone. Dataset is ready for unifolm-wma.")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/run_real_eval_server.sh
+++ b/scripts/run_real_eval_server.sh
@@ -9,7 +9,7 @@ datasets=(
 
 
 for dataset in "${datasets[@]}"; do
-    CUDA_VISIBLE_DEVICES=0 python3 scripts/evaluation/real_eval_server.py \
+    CUDA_VISIBLE_DEVICES=0 python3 -u scripts/evaluation/real_eval_server.py \
     --seed ${seed} \
     --ckpt_path $ckpt \
     --config $config \

--- a/scripts/run_world_model_interaction.sh
+++ b/scripts/run_world_model_interaction.sh
@@ -1,8 +1,8 @@
 model_name=testing
-ckpt=/path/to/model/checkpoint
+ckpt=/home/waheedbrown/workspaces/git/unifolm-world-model-action/waheed_models/unifolm_wma_base.ckpt
 config=configs/inference/world_model_interaction.yaml
 seed=123
-res_dir="/path/to/result/directory"
+res_dir="/home/waheedbrown/workspaces/git/unifolm-world-model-action/results"
 
 datasets=(
     "unitree_z1_stackbox"
@@ -29,7 +29,7 @@ for i in "${!datasets[@]}"; do
     --unconditional_guidance_scale 1.0 \
     --ddim_steps 50 \
     --ddim_eta 1.0 \
-    --prompt_dir "/path/to/unifolm-world-model-action/examples/world_model_interaction_prompts" \
+    --prompt_dir "/home/waheedbrown/workspaces/git/unifolm-world-model-action/examples/world_model_interaction_prompts" \
     --dataset ${dataset} \
     --video_length 16 \
     --frame_stride ${fs} \

--- a/src/unifolm_wma/models/diffusion_head/conditional_unet1d.py
+++ b/src/unifolm_wma/models/diffusion_head/conditional_unet1d.py
@@ -1,6 +1,7 @@
 import logging
 import torch
 import torch.nn as nn
+import torch.nn.functional as F
 import einops
 
 from einops import rearrange, repeat
@@ -90,12 +91,25 @@ class CrossAttention(nn.Module):
                     b * self.heads, t.shape[1], self.dim_head).contiguous(),
             (q, k, v),
         )
+
+        # NVIDIA DGX Spark CUDA 12.1 xformers compatibility
+        orig_dtype = q.dtype
+        q, k, v = q.to(torch.bfloat16), k.to(torch.bfloat16), v.to(torch.bfloat16)
+
         # actually compute the attention, what we cannot get enough of
-        out = xformers.ops.memory_efficient_attention(q,
-                                                      k,
-                                                      v,
-                                                      attn_bias=None,
-                                                      op=None)
+        if q.is_cuda and torch.cuda.get_device_capability(q.device)[0] >= 12:
+            out = F.scaled_dot_product_attention(q.unsqueeze(1),
+                                                 k.unsqueeze(1),
+                                                 v.unsqueeze(1),
+                                                 attn_mask=None).squeeze(1)
+        else:
+            out = xformers.ops.memory_efficient_attention(q,
+                                                          k,
+                                                          v,
+                                                          attn_bias=None,
+                                                          op=None)
+        
+        out = out.to(orig_dtype)
         out = (out.unsqueeze(0).reshape(
             b, self.heads, out.shape[1],
             self.dim_head).permute(0, 2, 1,

--- a/src/unifolm_wma/models/samplers/ddim.py
+++ b/src/unifolm_wma/models/samplers/ddim.py
@@ -19,8 +19,8 @@ class DDIMSampler(object):
 
     def register_buffer(self, name, attr):
         if type(attr) == torch.Tensor:
-            if attr.device != torch.device("cuda"):
-                attr = attr.to(torch.device("cuda"))
+            if attr.device != self.model.device:
+                attr = attr.to(self.model.device)
         setattr(self, name, attr)
 
     def make_schedule(self,

--- a/src/unifolm_wma/modules/attention.py
+++ b/src/unifolm_wma/modules/attention.py
@@ -125,7 +125,6 @@ class CrossAttention(nn.Module):
         context = default(context, x)
 
         if self.image_cross_attention and not spatial_self_attn:
-            assert 1 > 2, ">>> ERROR: should setup xformers and use efficient_forward ..."
             context_agent_state = context[:, :self.agent_state_context_len, :]
             context_agent_action = context[:,
                                            self.agent_state_context_len:self.

--- a/src/unifolm_wma/modules/attention.py
+++ b/src/unifolm_wma/modules/attention.py
@@ -291,11 +291,28 @@ class CrossAttention(nn.Module):
                         b * self.heads, t.shape[1], self.dim_head).contiguous(),
                 (k, v),
             )
-            out = xformers.ops.memory_efficient_attention(q,
-                                                          k,
-                                                          v,
-                                                          attn_bias=None,
-                                                          op=None)
+
+            # NVIDIA DGX Spark CUDA 12.1 xformers compatibility
+            # 1. Save original dtype and cast to bfloat16 for Blackwell
+            orig_dtype = q.dtype
+            q, k, v = q.to(torch.bfloat16), k.to(torch.bfloat16), v.to(torch.bfloat16)
+
+            # 2. Use the existing xformers call
+            if q.is_cuda and torch.cuda.get_device_capability(q.device)[0] >= 12:
+                out = F.scaled_dot_product_attention(q.unsqueeze(1),
+                                                     k.unsqueeze(1),
+                                                     v.unsqueeze(1),
+                                                     attn_mask=None).squeeze(1)
+            else:
+                out = xformers.ops.memory_efficient_attention(q,
+                                                              k,
+                                                              v,
+                                                              attn_bias=None,
+                                                              op=None)
+            
+            # 3. Cast the output back to prevent downstream type mismatches
+            out = out.to(orig_dtype)
+
             out = (out.unsqueeze(0).reshape(
                 b, self.heads, out.shape[1],
                 self.dim_head).permute(0, 2, 1,
@@ -311,11 +328,27 @@ class CrossAttention(nn.Module):
                         ),
                 (k_ip, v_ip),
             )
-            out_ip = xformers.ops.memory_efficient_attention(q,
-                                                             k_ip,
-                                                             v_ip,
-                                                             attn_bias=None,
-                                                             op=None)
+
+            # NVIDIA DGX Spark CUDA 12.1 xformers compatibility
+            # Query/Key/Value all need the same dtype
+            # 1. Cast k and v to bfloat16
+            k_ip, v_ip = k_ip.to(torch.bfloat16), v_ip.to(torch.bfloat16)
+
+            if q.is_cuda and torch.cuda.get_device_capability(q.device)[0] >= 12:
+                out_ip = F.scaled_dot_product_attention(q.unsqueeze(1),
+                                                         k_ip.unsqueeze(1),
+                                                         v_ip.unsqueeze(1),
+                                                         attn_mask=None).squeeze(1)
+            else:
+                out_ip = xformers.ops.memory_efficient_attention(q,
+                                                                 k_ip,
+                                                                 v_ip,
+                                                                 attn_bias=None,
+                                                                 op=None)
+            
+            # 2. Cast output back to float32
+            out_ip = out_ip.to(orig_dtype)
+
             out_ip = (out_ip.unsqueeze(0).reshape(
                 b, self.heads, out_ip.shape[1],
                 self.dim_head).permute(0, 2, 1,
@@ -331,11 +364,27 @@ class CrossAttention(nn.Module):
                         ),
                 (k_as, v_as),
             )
-            out_as = xformers.ops.memory_efficient_attention(q,
-                                                             k_as,
-                                                             v_as,
-                                                             attn_bias=None,
-                                                             op=None)
+
+            # NVIDIA DGX Spark CUDA 12.1 xformers compatibility
+            # Query/Key/Value all need the same dtype
+            # 1. Cast k and v to bfloat16
+            k_as, v_as = k_as.to(torch.bfloat16), v_as.to(torch.bfloat16)
+
+            if q.is_cuda and torch.cuda.get_device_capability(q.device)[0] >= 12:
+                out_as = F.scaled_dot_product_attention(q.unsqueeze(1),
+                                                         k_as.unsqueeze(1),
+                                                         v_as.unsqueeze(1),
+                                                         attn_mask=None).squeeze(1)
+            else:
+                out_as = xformers.ops.memory_efficient_attention(q,
+                                                                 k_as,
+                                                                 v_as,
+                                                                 attn_bias=None,
+                                                                 op=None)
+            
+            # 2. Cast output back to float32
+            out_as = out_as.to(orig_dtype)
+
             out_as = (out_as.unsqueeze(0).reshape(
                 b, self.heads, out_as.shape[1],
                 self.dim_head).permute(0, 2, 1,
@@ -353,10 +402,26 @@ class CrossAttention(nn.Module):
 
             attn_mask_aa = attn_mask_aa.unsqueeze(1).repeat(1,self.heads,1,1).reshape(
                     b * self.heads, attn_mask_aa.shape[1], attn_mask_aa.shape[2])
-            attn_mask_aa = attn_mask_aa.to(q.dtype)
+            
+            # NVIDIA DGX Spark CUDA 12.1 xformers compatibility
+            # Query/Key/Value all need the same dtype
+            # 1. Cast k and v to bfloat16
+            k_aa, v_aa = k_aa.to(torch.bfloat16), v_aa.to(torch.bfloat16)
 
-            out_aa = xformers.ops.memory_efficient_attention(
-                q, k_aa, v_aa, attn_bias=attn_mask_aa, op=None)
+            # 2. The mask needs to match the cast type
+            attn_mask_aa = attn_mask_aa.to(torch.bfloat16)
+
+            if q.is_cuda and torch.cuda.get_device_capability(q.device)[0] >= 12:
+                out_aa = F.scaled_dot_product_attention(q.unsqueeze(1),
+                                                         k_aa.unsqueeze(1),
+                                                         v_aa.unsqueeze(1),
+                                                         attn_mask=attn_mask_aa.unsqueeze(1)).squeeze(1)
+            else:
+                out_aa = xformers.ops.memory_efficient_attention(
+                    q, k_aa, v_aa, attn_bias=attn_mask_aa, op=None)
+
+            # 3. Cast output back to float32
+            out_aa = out_aa.to(orig_dtype)
 
             out_aa = (out_aa.unsqueeze(0).reshape(
                 b, self.heads, out_aa.shape[1],

--- a/src/unifolm_wma/modules/encoders/condition.py
+++ b/src/unifolm_wma/modules/encoders/condition.py
@@ -49,7 +49,9 @@ class ClassEmbedder(nn.Module):
         c = self.embedding(c)
         return c
 
-    def get_unconditional_conditioning(self, bs, device="cuda"):
+    def get_unconditional_conditioning(self, bs, device=None):
+        if device is None:
+            device = "cuda" if torch.cuda.is_available() else "cpu"
         uc_class = self.n_classes - 1  # 1000 classes --> 0 ... 999, one extra class for ucg (class 1000)
         uc = torch.ones((bs, ), device=device) * uc_class
         uc = {self.key: uc}
@@ -67,7 +69,7 @@ class FrozenT5Embedder(AbstractEncoder):
 
     def __init__(self,
                  version="google/t5-v1_1-xxl",
-                 device="cuda",
+                 device='cuda' if torch.cuda.is_available() else 'cpu',
                  max_length=77,
                  freeze=True
                  ):  # others are google/t5-v1_1-xl and google/t5-v1_1-xxl
@@ -109,7 +111,7 @@ class FrozenCLIPEmbedder(AbstractEncoder):
 
     def __init__(self,
                  version="openai/clip-vit-large-patch14",
-                 device="cuda",
+                 device='cuda' if torch.cuda.is_available() else 'cpu',
                  max_length=77,
                  freeze=True,
                  layer="last",
@@ -215,7 +217,7 @@ class FrozenOpenCLIPEmbedder(AbstractEncoder):
     def __init__(self,
                  arch="ViT-H-14",
                  version="laion2b_s32b_b79k",
-                 device="cuda",
+                 device='cuda' if torch.cuda.is_available() else 'cpu',
                  max_length=77,
                  freeze=True,
                  layer="last"):
@@ -281,7 +283,7 @@ class FrozenOpenCLIPImageEmbedder(AbstractEncoder):
     def __init__(self,
                  arch="ViT-H-14",
                  version="laion2b_s32b_b79k",
-                 device="cuda",
+                 device='cuda' if torch.cuda.is_available() else 'cpu',
                  max_length=77,
                  freeze=True,
                  layer="pooled",
@@ -358,7 +360,7 @@ class FrozenOpenCLIPImageEmbedderV2(AbstractEncoder):
     def __init__(self,
                  arch="ViT-H-14",
                  version="laion2b_s32b_b79k",
-                 device="cuda",
+                 device='cuda' if torch.cuda.is_available() else 'cpu',
                  freeze=True,
                  layer="pooled",
                  antialias=True):
@@ -457,7 +459,7 @@ class FrozenCLIPT5Encoder(AbstractEncoder):
     def __init__(self,
                  clip_version="openai/clip-vit-large-patch14",
                  t5_version="google/t5-v1_1-xl",
-                 device="cuda",
+                 device='cuda' if torch.cuda.is_available() else 'cpu',
                  clip_max_length=77,
                  t5_max_length=77):
         super().__init__()

--- a/src/unifolm_wma/modules/vision/dinosiglip_vit.py
+++ b/src/unifolm_wma/modules/vision/dinosiglip_vit.py
@@ -240,15 +240,11 @@ class DinoSigLIPViTBackbone(VisionBackbone):
         siglip_normalizer = Normalize(
             mean=torch.tensor([0.5000, 0.5000, 0.5000]),
             std=torch.tensor([0.5000, 0.5000, 0.5000]))
+        device = next(self.dino_featurizer.parameters()).device
         pixel_values = {
-            'dino': dino_normalizer(img),
-            'siglip': siglip_normalizer(img)
+            'dino': dino_normalizer(img).to(device),
+            'siglip': siglip_normalizer(img).to(device)
         }
-
-        if self.on_gpu:
-            pixel_values = {k: v.cuda() for k, v in pixel_values.items()}
-        elif next(self.dino_featurizer.parameters()).device.type != 'cpu':
-            self.on_gpu = True
         """Runs the transformed image/pixel tensors through each vision backbone, returning concatenated patches."""
         dino_patches = self.dino_featurizer(pixel_values["dino"])
         siglip_patches = self.siglip_featurizer(pixel_values["siglip"])

--- a/src/unifolm_wma/utils/save_video.py
+++ b/src/unifolm_wma/utils/save_video.py
@@ -2,6 +2,7 @@ import os
 import torch
 import numpy as np
 import torchvision
+import imageio
 
 from tqdm import tqdm
 from PIL import Image
@@ -28,11 +29,7 @@ def frames_to_mp4(frame_dir, output_path, fps):
 
     videos = read_first_n_frames(frame_dir, num_frames=None)
     videos = videos.mul(255).to(torch.uint8).permute(0, 2, 3, 1)
-    torchvision.io.write_video(output_path,
-                               videos,
-                               fps=fps,
-                               video_codec='h264',
-                               options={'crf': '10'})
+    imageio.mimsave(output_path, list(videos.numpy()), fps=fps)
 
 
 def tensor_to_mp4(video, savepath, fps, rescale=True, nrow=None):
@@ -52,13 +49,8 @@ def tensor_to_mp4(video, savepath, fps, rescale=True, nrow=None):
     grid = torch.clamp(grid.float(), -1., 1.)
     if rescale:
         grid = (grid + 1.0) / 2.0
-    grid = (grid * 255).to(torch.uint8).permute(
-        0, 2, 3, 1)
-    torchvision.io.write_video(savepath,
-                               grid,
-                               fps=fps,
-                               video_codec='h264',
-                               options={'crf': '10'})
+    grid = (grid * 255).to(torch.uint8).permute(0, 2, 3, 1)
+    imageio.mimsave(savepath, list(grid.numpy()), fps=fps)
 
 
 def tensor2videogrids(video, root, filename, fps, rescale=True, clamp=True):
@@ -81,11 +73,7 @@ def tensor2videogrids(video, root, filename, fps, rescale=True, clamp=True):
     grid = (grid * 255).to(torch.uint8).permute(
         0, 2, 3, 1)
     path = os.path.join(root, filename)
-    torchvision.io.write_video(path,
-                               grid,
-                               fps=fps,
-                               video_codec='h264',
-                               options={'crf': '10'})
+    imageio.mimsave(path, list(grid.numpy()), fps=fps)
 
 
 def log_local(batch_logs, save_dir, filename, save_fps=10, rescale=True):
@@ -129,11 +117,7 @@ def log_local(batch_logs, save_dir, filename, save_fps=10, rescale=True):
                 grid = (grid + 1.0) / 2.0
             grid = (grid * 255).to(torch.uint8).permute(0, 2, 3, 1)
             path = os.path.join(save_dir, "%s-%s.mp4" % (key, filename))
-            torchvision.io.write_video(path,
-                                       grid,
-                                       fps=save_fps,
-                                       video_codec='h264',
-                                       options={'crf': '10'})
+            imageio.mimsave(path, list(grid.numpy()), fps=save_fps)
 
             # Save frame sheet
             img = value
@@ -251,8 +235,4 @@ def npz_to_video_grid(data_path,
         os.makedirs(os.path.dirname(out_path), exist_ok=True)
     frame_grids = (torch.stack(frame_grids) * 255).to(torch.uint8).permute(
         0, 2, 3, 1)
-    torchvision.io.write_video(out_path,
-                               frame_grids,
-                               fps=fps,
-                               video_codec='h264',
-                               options={'crf': '10'})
+    imageio.mimsave(out_path, list(frame_grids.numpy()), fps=fps)

--- a/unitree_deploy/README.md
+++ b/unitree_deploy/README.md
@@ -28,7 +28,7 @@ pip install -e .
 pip install -e ".[lerobot]"
 
 git clone https://github.com/unitreerobotics/unitree_sdk2_python.git
-cd unitree_sdk2_python  && pip install -e . && cd ..
+cd unitree_sdk2_python && pip install -e . && cd ..
 ```
 
 ---
@@ -212,7 +212,31 @@ Run the following tests:
 
 # 5. 🤔 Troubleshooting
 
-For assistance, contact the project maintainer or refer to the respective GitHub repository documentation. 📖
+## `unitree_sdk2_python` install fails with "Could not locate cyclonedds"
+
+The `cyclonedds` Python package builds from source and needs to find the CycloneDDS C library at build time.
+If you see:
+
+```
+Could not locate cyclonedds. Try to set CYCLONEDDS_HOME or CMAKE_PREFIX_PATH
+```
+
+Set `CYCLONEDDS_HOME` to your CycloneDDS install prefix before running `pip install`:
+
+```bash
+# Unitree G1 ships with CycloneDDS pre-built in ~/cyclonedds_ws:
+export CYCLONEDDS_HOME=~/cyclonedds_ws/install/cyclonedds
+
+cd unitree_sdk2_python && pip install -e . && cd ..
+```
+
+You can persist this in your shell config so it applies to future installs:
+
+```bash
+echo 'export CYCLONEDDS_HOME=~/cyclonedds_ws/install/cyclonedds' >> ~/.bashrc
+```
+
+For assistance with other issues, contact the project maintainer or refer to the respective GitHub repository documentation. 📖
 
 
 # 6. 🙏 Acknowledgement

--- a/unitree_deploy/README.md
+++ b/unitree_deploy/README.md
@@ -36,9 +36,146 @@ cd unitree_sdk2_python && pip install -e . && cd ..
 
 **Tip: Keep all devices on the same LAN**
 
-## 2.1 🤖 Run G1 with Dex_1 Gripper 
+## 2.1 🤖 Run G1 with Brainco Revo2 Five-Finger Hands
 
-### 2.1.1 📷 Image Capture Service Setup (G1 Board) 
+### 2.1.0 🧠 Architecture Overview
+
+The Brainco Revo2 hands are driven by a ROS2 node (`stark_node`) that runs in a separate conda environment (`g1brainco`, Python 3.8, ROS2 Foxy). The `unitree_deploy` client runs in its own conda env (`unitree_deploy`, Python 3.10). Because these two environments cannot share the same Python process, a lightweight **TCP bridge** (`brainco_bridge.py`) mediates between them over `localhost:9877` using newline-delimited JSON.
+
+```
+stark_node (ROS2)  <-- /motor_status{,_r} / joint_commands_{left,right} -->
+brainco_bridge.py (g1brainco env, TCP 127.0.0.1:9877)  <-->
+Brainco_DualHand_Controller (unitree_deploy env, robot_client.py)
+```
+
+**Robot specifics (G1 23-DOF + Brainco):**
+- Waist: 1 DOF (yaw/twist, index 12)
+- Arms: 5 real DOFs each (shoulder ×3, elbow, forearm roll); **no wrist pitch/yaw**
+- Hands: Brainco Revo2 five-finger, USB ports `/dev/ttyUSB1` (left) and `/dev/ttyUSB2` (right)
+- Action space: 14 arm DOFs (4 phantom wrist slots kept for SDK compatibility) + 12 hand DOFs = **26 total**
+- Hand DOF range: 0.0 = open, 1.0 = closed
+- Finger order (both hands): thumb, thumb_aux, index, middle, ring, pinky
+
+---
+
+### 2.1.1 🛠️ Prerequisites
+
+In addition to the base `unitree_deploy` env setup (Section 1), you need the `ros2_stark_ws` workspace built and the `g1brainco` conda env set up on the robot. Follow the [unitree-g1-brainco-hand](https://github.com/unitreerobotics/unitree-g1-brainco-hand) setup guide for this.
+
+**Python version fix:** The Unitree G1 robot runs Python 3.10.12. If `pip install -e .` inside `unitree_deploy/` fails with `requires-python == 3.10.18`, edit `unitree_deploy/pyproject.toml` on the robot:
+
+```toml
+# Change:
+requires-python = "==3.10.18"
+# To:
+requires-python = ">=3.10"
+```
+
+**pinocchio / libgomp fix (aarch64):** pinocchio ships a bundled `libgomp.so.1` that conflicts with the system GCC one on ARM64. Add this to `~/.bashrc` or set it each session before running the client:
+
+```bash
+export LD_PRELOAD=/home/unitree/miniconda3/envs/unitree_deploy/lib/libgomp.so.1
+```
+
+---
+
+### 2.1.2 📷 Image Capture Service Setup (G1 Board)
+
+[To open the image_server, follow these steps](https://github.com/unitreerobotics/xr_teleoperate?tab=readme-ov-file#31-%EF%B8%8F-image-service)
+
+1. Connect to the G1 board:
+    ```bash
+    ssh unitree@192.168.123.164  # Password: 123
+    ```
+
+2. Activate the environment and start the image server:
+    ```bash
+    conda activate tv
+    cd ~/image_server
+    python image_server.py
+    ```
+
+---
+
+### 2.1.3 🤚 Brainco Hand Setup (Three Terminals, All on Robot)
+
+Open three SSH sessions to the robot (`ssh unitree@192.168.123.164`).
+
+**Terminal 1 — stark_node (ROS2 hand driver):**
+
+```bash
+conda activate g1brainco
+source ~/unitree_ros2/setup.sh
+source ~/unitree-g1-brainco-hand/ros2_stark_ws/install/setup.bash
+ros2 launch stark_bringup brainco_launch.py
+```
+
+Wait for the stark_node to connect to both hands via `/dev/ttyUSB1` and `/dev/ttyUSB2` before proceeding.
+
+**Terminal 2 — brainco_bridge.py (ROS2 ↔ TCP bridge):**
+
+```bash
+conda activate g1brainco
+source ~/unitree_ros2/setup.sh
+source ~/unitree-g1-brainco-hand/ros2_stark_ws/install/setup.bash
+python ~/unifolm-world-model-action/unitree_deploy/scripts/brainco_bridge.py
+```
+
+You should see: `[bridge] TCP server listening on 127.0.0.1:9877`
+
+**Terminal 3 — robot client:**
+
+```bash
+conda activate unitree_deploy
+cd ~/unifolm-world-model-action/unitree_deploy
+
+# Required: preload libgomp to prevent pinocchio TLS error on aarch64
+export LD_PRELOAD=/home/unitree/miniconda3/envs/unitree_deploy/lib/libgomp.so.1
+
+# Required: point the client at the inference server (change IP as needed)
+export INFERENCE_SERVER_HOST=192.168.123.222
+
+python scripts/robot_client.py \
+    --robot_type g1_brainco \
+    --language_instruction "your task here"
+```
+
+The robot client will:
+1. Connect to the G1 arm (DDS), Brainco hands (bridge), and image client
+2. Move arms to Ready Mode position (`go_start()`)
+3. Open both hands (all zeros)
+4. Begin polling the inference server for actions
+
+---
+
+### 2.1.4 ✅ Testing
+
+- **Brainco Bridge Test** (run in `g1brainco` env while bridge is running):
+  ```bash
+  python -c "
+  import socket, json
+  s = socket.socket(); s.connect(('127.0.0.1', 9877))
+  s.sendall(b'{\"cmd\": \"get\"}\n')
+  print(s.recv(1024).decode())
+  s.close()
+  "
+  ```
+
+- **G1 Arm Test:**
+  ```bash
+  python test/arm/g1/test_g1_arm.py
+  ```
+
+- **Image Client Camera Test:**
+  ```bash
+  python test/camera/test_image_client_camera.py
+  ```
+
+---
+
+## 2.2 🤖 Run G1 with Dex_1 Gripper
+
+### 2.2.1 📷 Image Capture Service Setup (G1 Board) 
 
 [To open the image_server, follow these steps](https://github.com/unitreerobotics/xr_teleoperate?tab=readme-ov-file#31-%EF%B8%8F-image-service)
 1. Connect to the G1 board:
@@ -55,7 +192,7 @@ cd unitree_sdk2_python && pip install -e . && cd ..
 
 ---
 
-### 2.1.2 🤏 Dex_1 Gripper Service Setup (Development PC2)
+### 2.2.2 🤏 Dex_1 Gripper Service Setup (Development PC2)
 
 Refer to the [Dex_1 Gripper Installation Guide](https://github.com/unitreerobotics/dex1_1_service?tab=readme-ov-file#1--installation) for detailed setup instructions.
 
@@ -76,7 +213,7 @@ Refer to the [Dex_1 Gripper Installation Guide](https://github.com/unitreeroboti
 
 ---
 
-### 2.1.2 ✅Testing 
+### 2.2.3 ✅Testing 
 
 Perform the following tests to ensure proper functionality:
 
@@ -237,6 +374,56 @@ echo 'export CYCLONEDDS_HOME=~/cyclonedds_ws/install/cyclonedds' >> ~/.bashrc
 ```
 
 For assistance with other issues, contact the project maintainer or refer to the respective GitHub repository documentation. 📖
+
+---
+
+## `pinocchio` import fails: "cannot allocate memory in static TLS block" (aarch64)
+
+On ARM64 (G1 robot board), pinocchio ships a bundled `libgomp.so.1` that cannot be loaded via normal `dlopen` after the TLS block is full:
+
+```
+ImportError: /home/unitree/miniconda3/envs/unitree_deploy/lib/python3.10/site-packages/
+  pinocchio/../../libgomp.so.1: cannot allocate memory in static TLS block
+```
+
+Fix — preload the library before Python starts:
+
+```bash
+export LD_PRELOAD=/home/unitree/miniconda3/envs/unitree_deploy/lib/libgomp.so.1
+```
+
+Add this to `~/.bashrc` for persistence, or prefix every `python ...` invocation.
+Note: the bare assignment `LD_PRELOAD=...` (without `export`) does **not** propagate to subprocess calls from Python.
+
+---
+
+## Brainco bridge connection refused
+
+If the robot client prints `❌ Brainco bridge connect failed: [Errno 111] Connection refused`, the TCP bridge is not running. Make sure Terminal 2 (`brainco_bridge.py`) is running in the `g1brainco` env and that `stark_node` (Terminal 1) started successfully first.
+
+---
+
+## Arms whirring on startup (competing init poses)
+
+Two sources can fight over the arm target position at startup:
+1. `go_start()` in `G1_29_ArmController` drives to `G1ArmConfig.init_pose`
+2. `env.step(INIT_POSE[...])` in `robot_client.py` sends a target position immediately after
+
+These are aligned to the same Ready Mode values so they do not compete. If you modify either, make sure both `INIT_POSE['g1_brainco']` in `scripts/robot_client.py` and `ready_mode_pose` in `brainco_dual_arm_default_factory()` in `robot/robot_configs.py` use the same values.
+
+The `G1_29_ArmController` also initialises `self.q_target` to `init_pose` (not zeros) so the background control loop holds the start position instead of driving back to the zero pose.
+
+---
+
+## Inference server normalizer dimension mismatch (26 vs 12)
+
+The `g1_brainco` robot type uses a 26-DOF observation state (14 arm + 12 hand). If the trained model's dataset was recorded with a different state representation (e.g., 12 DOFs only), you will see:
+
+```
+RuntimeError: The size of tensor a (26) must match the size of tensor b (12) at non-singleton dimension 1
+```
+
+This means the model checkpoint and the `--dataset_name` passed to the inference server do not match the 26-DOF action space. Use a model checkpoint trained on `g1_brainco` data, or check `configs/inference/world_model_decision_making.yaml` and verify the `dataset_name` matches a dataset with 26-DOF state/action dimensions.
 
 
 # 6. 🙏 Acknowledgement

--- a/unitree_deploy/README.md
+++ b/unitree_deploy/README.md
@@ -107,7 +107,7 @@ Open three SSH sessions to the robot (`ssh unitree@192.168.123.164`).
 conda activate g1brainco
 source ~/unitree_ros2/setup.sh
 source ~/unitree-g1-brainco-hand/ros2_stark_ws/install/setup.bash
-ros2 launch stark_bringup brainco_launch.py
+ros2 launch ros2_stark_controller stark_launch.py
 ```
 
 Wait for the stark_node to connect to both hands via `/dev/ttyUSB1` and `/dev/ttyUSB2` before proceeding.

--- a/unitree_deploy/README.md
+++ b/unitree_deploy/README.md
@@ -403,9 +403,21 @@ If the robot client prints `❌ Brainco bridge connect failed: [Errno 111] Conne
 
 ---
 
-## Arms whirring on startup (competing init poses)
+## Arms jerking and whirring on startup
 
-Two sources can fight over the arm target position at startup:
+**Root cause: robot in Ready Mode (Locked Standing)**
+
+If the robot is in Ready Mode (Locked Standing) when the robot client starts, the G1's built-in motion controller and `unitree_deploy`'s arm controller send competing control signals to the same joints. This produces constant jerking and whirring even before any inference action is executed.
+
+**Fix: switch the robot to Development Mode before running the client.**
+
+On the robot's App (or via the Unitree controller), select **Development Mode** before starting `robot_client.py`. Development Mode disables the built-in standing controller, giving `unitree_deploy` exclusive control over the joints. The jerking and whirring stop immediately.
+
+---
+
+**Secondary cause: competing init poses inside `unitree_deploy`**
+
+Even in Development Mode, two sources inside the code can fight over the arm target position at startup:
 1. `go_start()` in `G1_29_ArmController` drives to `G1ArmConfig.init_pose`
 2. `env.step(INIT_POSE[...])` in `robot_client.py` sends a target position immediately after
 

--- a/unitree_deploy/scripts/brainco_bridge.py
+++ b/unitree_deploy/scripts/brainco_bridge.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+"""
+Bridge: ROS2 stark_node (Brainco Revo2) <-> TCP socket for unitree_deploy.
+
+Run in the g1brainco conda env AFTER the stark_node is already running:
+
+    conda activate g1brainco
+    source ~/unitree_ros2/setup.sh
+    source ~/unitree-g1-brainco-hand/ros2_stark_ws/install/setup.bash
+    python ~/unifolm-world-model-action/unitree_deploy/scripts/brainco_bridge.py
+
+Protocol: newline-delimited JSON over TCP on 127.0.0.1:9877
+  Read state:   {"cmd": "get"}
+    -> {"left": [6 floats 0-1], "right": [6 floats 0-1]}
+  Send command: {"cmd": "set", "left": [6 floats 0-1], "right": [6 floats 0-1]}
+    -> {"ok": true}
+
+Finger order (both hands): thumb, thumb_aux, index, middle, ring, pinky
+"""
+import json
+import socket
+import threading
+
+import rclpy
+from rclpy.node import Node
+from sensor_msgs.msg import JointState
+
+from ros2_stark_interfaces.msg import MotorStatus
+
+HOST = "127.0.0.1"
+PORT = 9877
+JOINT_NAMES = ["thumb", "thumb_aux", "index", "middle", "ring", "pinky"]
+
+
+class BrancoBridge(Node):
+    def __init__(self):
+        super().__init__("brainco_bridge")
+        self._lock = threading.Lock()
+        self._positions_left = [0.0] * 6
+        self._positions_right = [0.0] * 6
+
+        self.sub_left = self.create_subscription(
+            MotorStatus, "motor_status", self._cb_left, 10
+        )
+        self.sub_right = self.create_subscription(
+            MotorStatus, "motor_status_r", self._cb_right, 10
+        )
+        self.pub_left = self.create_publisher(JointState, "joint_commands_left", 10)
+        self.pub_right = self.create_publisher(JointState, "joint_commands_right", 10)
+        self.get_logger().info("BrancoBridge node ready.")
+
+    def _cb_left(self, msg):
+        with self._lock:
+            # MotorStatus.positions is uint8[6], range 0-255; map to 0.0-1.0
+            self._positions_left = [p / 255.0 for p in msg.positions]
+
+    def _cb_right(self, msg):
+        with self._lock:
+            self._positions_right = [p / 255.0 for p in msg.positions]
+
+    def get_state(self):
+        with self._lock:
+            return list(self._positions_left), list(self._positions_right)
+
+    def send_cmd(self, left_positions, right_positions):
+        now = self.get_clock().now().to_msg()
+        for positions, pub in [
+            (left_positions, self.pub_left),
+            (right_positions, self.pub_right),
+        ]:
+            msg = JointState()
+            msg.header.stamp = now
+            msg.name = JOINT_NAMES
+            msg.position = [float(p) for p in positions]
+            pub.publish(msg)
+
+
+def _handle_client(conn, bridge):
+    buf = ""
+    try:
+        while True:
+            data = conn.recv(1024)
+            if not data:
+                break
+            buf += data.decode("utf-8")
+            while "\n" in buf:
+                line, buf = buf.split("\n", 1)
+                line = line.strip()
+                if not line:
+                    continue
+                req = json.loads(line)
+                if req["cmd"] == "get":
+                    left, right = bridge.get_state()
+                    resp = json.dumps({"left": left, "right": right}) + "\n"
+                    conn.sendall(resp.encode("utf-8"))
+                elif req["cmd"] == "set":
+                    bridge.send_cmd(req["left"], req["right"])
+                    conn.sendall(json.dumps({"ok": True}).encode("utf-8") + b"\n")
+    except Exception as e:
+        bridge.get_logger().warn(f"[bridge] client error: {e}")
+    finally:
+        conn.close()
+
+
+def _serve(bridge):
+    server = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    server.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    server.bind((HOST, PORT))
+    server.listen(5)
+    bridge.get_logger().info(f"[bridge] TCP server listening on {HOST}:{PORT}")
+    while True:
+        conn, addr = server.accept()
+        bridge.get_logger().info(f"[bridge] connection from {addr}")
+        t = threading.Thread(target=_handle_client, args=(conn, bridge), daemon=True)
+        t.start()
+
+
+def main():
+    rclpy.init()
+    bridge = BrancoBridge()
+
+    server_thread = threading.Thread(target=_serve, args=(bridge,), daemon=True)
+    server_thread.start()
+
+    rclpy.spin(bridge)
+    rclpy.shutdown()
+
+
+if __name__ == "__main__":
+    main()

--- a/unitree_deploy/scripts/robot_client.py
+++ b/unitree_deploy/scripts/robot_client.py
@@ -32,13 +32,14 @@ INIT_POSE = {
     'z1_dual_dex1_realsense': np.array([-1.0262332,  1.4281361, -1.2149128,  0.6473399, -0.12425245, 0.44945636,  0.89584476,  1.2593982, -1.0737865,  0.6672816, 0.39730102, -0.47400007, 0.9894176, 0.9817477 ], dtype=np.float32),
     'z1_realsense': np.array([-0.06940782, 1.4751548, -0.7554075, 1.0501366, 0.02931615, -0.02810347, -0.99238837], dtype=np.float32),
     # 14 arm DOFs (indices 0-13 map to G1_29_JointArmIndex 15-28; slots 5,6,12,13 are phantom
-    # wrist pitch/yaw absent on 23-DOF robot) + 12 hand DOFs (6 per Brainco hand, 0.0=open)
-    # Arm values match the G1 Ready Mode position observed on this robot (elbows ~56° bent).
+    # wrist pitch/yaw absent on 23-DOF robot) + 12 hand DOFs (6 per Brainco hand, 0.0=open).
+    # Arm values match G1ArmConfig.init_pose in brainco_dual_arm_default_factory — keeping
+    # them identical prevents go_start() and env.step() from fighting each other on startup.
     'g1_brainco': np.array([
-        # left:  ShPitch  ShRoll   ShYaw    Elbow    ForearmRoll  WrPitch(0) WrYaw(0)
-                  0.285,   0.127,   0.014,   0.979,   0.035,       0.0,       0.0,
-        # right: ShPitch  ShRoll   ShYaw    Elbow    ForearmRoll  WrPitch(0) WrYaw(0)
-                  0.291,  -0.127,   0.005,   0.983,  -0.047,       0.0,       0.0,
+        # left:  ShPitch  ShRoll   ShYaw   Elbow   ForearmRoll  WrPitch(0) WrYaw(0)
+                  0.29,    0.13,    0.0,    0.978,  0.0,         0.0,       0.0,
+        # right: ShPitch  ShRoll   ShYaw   Elbow   ForearmRoll  WrPitch(0) WrYaw(0)
+                  0.29,   -0.13,    0.0,    0.981,  0.0,         0.0,       0.0,
         # hands: all open (12 zeros)
         0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
     ], dtype=np.float32),

--- a/unitree_deploy/scripts/robot_client.py
+++ b/unitree_deploy/scripts/robot_client.py
@@ -22,8 +22,8 @@ from unitree_deploy.utils.eval_utils import (
 # -----------------------------------------------------------------------------
 os.environ["http_proxy"] = ""
 os.environ["https_proxy"] = ""
-HOST = "127.0.0.1"
-PORT = 8000
+HOST = os.environ.get("INFERENCE_SERVER_HOST", "127.0.0.1")
+PORT = int(os.environ.get("INFERENCE_SERVER_PORT", "8000"))
 BASE_URL = f"http://{HOST}:{PORT}"
 
 # fmt: off

--- a/unitree_deploy/scripts/robot_client.py
+++ b/unitree_deploy/scripts/robot_client.py
@@ -33,8 +33,15 @@ INIT_POSE = {
     'z1_realsense': np.array([-0.06940782, 1.4751548, -0.7554075, 1.0501366, 0.02931615, -0.02810347, -0.99238837], dtype=np.float32),
     # 14 arm DOFs (indices 0-13 map to G1_29_JointArmIndex 15-28; slots 5,6,12,13 are phantom
     # wrist pitch/yaw absent on 23-DOF robot) + 12 hand DOFs (6 per Brainco hand, 0.0=open)
-    # TODO: replace arm values with a pose calibrated for your specific robot
-    'g1_brainco': np.zeros(26, dtype=np.float32),
+    # Arm values match the G1 Ready Mode position observed on this robot (elbows ~56° bent).
+    'g1_brainco': np.array([
+        # left:  ShPitch  ShRoll   ShYaw    Elbow    ForearmRoll  WrPitch(0) WrYaw(0)
+                  0.285,   0.127,   0.014,   0.979,   0.035,       0.0,       0.0,
+        # right: ShPitch  ShRoll   ShYaw    Elbow    ForearmRoll  WrPitch(0) WrYaw(0)
+                  0.291,  -0.127,   0.005,   0.983,  -0.047,       0.0,       0.0,
+        # hands: all open (12 zeros)
+        0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+    ], dtype=np.float32),
 }
 ZERO_ACTION = {
     'g1_dex1': torch.zeros(16, dtype=torch.float32),

--- a/unitree_deploy/scripts/robot_client.py
+++ b/unitree_deploy/scripts/robot_client.py
@@ -31,16 +31,22 @@ INIT_POSE = {
     'g1_dex1': np.array([0.10559805, 0.02726714, -0.01210221, -0.33341318, -0.22513399, -0.02627627, -0.15437093,  0.1273793 , -0.1674708 , -0.11544029, -0.40095493,  0.44332668,  0.11566751,  0.3936641, 5.4, 5.4], dtype=np.float32),
     'z1_dual_dex1_realsense': np.array([-1.0262332,  1.4281361, -1.2149128,  0.6473399, -0.12425245, 0.44945636,  0.89584476,  1.2593982, -1.0737865,  0.6672816, 0.39730102, -0.47400007, 0.9894176, 0.9817477 ], dtype=np.float32),
     'z1_realsense': np.array([-0.06940782, 1.4751548, -0.7554075, 1.0501366, 0.02931615, -0.02810347, -0.99238837], dtype=np.float32),
+    # 14 arm DOFs (indices 0-13 map to G1_29_JointArmIndex 15-28; slots 5,6,12,13 are phantom
+    # wrist pitch/yaw absent on 23-DOF robot) + 12 hand DOFs (6 per Brainco hand, 0.0=open)
+    # TODO: replace arm values with a pose calibrated for your specific robot
+    'g1_brainco': np.zeros(26, dtype=np.float32),
 }
 ZERO_ACTION = {
     'g1_dex1': torch.zeros(16, dtype=torch.float32),
     'z1_dual_dex1_realsense': torch.zeros(14, dtype=torch.float32),
     'z1_realsense': torch.zeros(7, dtype=torch.float32),
+    'g1_brainco': torch.zeros(26, dtype=torch.float32),
 }
 CAM_KEY = {
     'g1_dex1': 'cam_right_high',
     'z1_dual_dex1_realsense': 'cam_high',
     'z1_realsense': 'cam_high',
+    'g1_brainco': 'cam_right_high',
 }
 # fmt: on
 

--- a/unitree_deploy/scripts/robot_client.py
+++ b/unitree_deploy/scripts/robot_client.py
@@ -48,7 +48,8 @@ ZERO_ACTION = {
     'g1_dex1': torch.zeros(16, dtype=torch.float32),
     'z1_dual_dex1_realsense': torch.zeros(14, dtype=torch.float32),
     'z1_realsense': torch.zeros(7, dtype=torch.float32),
-    'g1_brainco': torch.zeros(26, dtype=torch.float32),
+    # 12-dim: the model was trained on ee_state/ee_action (6 arm joints per arm, no hands).
+    'g1_brainco': torch.zeros(12, dtype=torch.float32),
 }
 CAM_KEY = {
     'g1_dex1': 'cam_right_high',
@@ -59,17 +60,48 @@ CAM_KEY = {
 # fmt: on
 
 
+def _g1_brainco_qpos_to_ee_state(qpos: np.ndarray) -> np.ndarray:
+    """Extract 12-dim ee_state from 26-dim g1_brainco qpos.
+
+    The training dataset stores ee_state as the first 6 joints of each arm
+    (qpos[0:6] = left, qpos[7:13] = right), matching the 12-dim normalizer
+    built from G1_WBT_Brainco_Pickup_Pillow.  The phantom wrist-yaw slots
+    (indices 6 and 13) and the 12 hand joints (indices 14-25) are omitted.
+    """
+    return np.concatenate([qpos[0:6], qpos[7:13]])
+
+
+def _g1_brainco_ee_action_to_qpos(ee_action: np.ndarray) -> np.ndarray:
+    """Map 12-dim predicted ee_action back to 26-dim qpos for robot execution.
+
+    Inserts zeros for phantom wrist-yaw slots (6 and 13) and keeps hands
+    fully open (zeros at indices 14-25).
+    """
+    qpos = np.zeros(26, dtype=np.float32)
+    qpos[0:6] = ee_action[0:6]    # left arm joints 0-5 (slot 5 = wrist pitch, ignored by hw)
+    # qpos[6] = 0.0                # left wrist yaw (phantom)
+    qpos[7:13] = ee_action[6:12]  # right arm joints 0-5
+    # qpos[13] = 0.0               # right wrist yaw (phantom)
+    # qpos[14:26] = 0.0            # hands open
+    return qpos
+
+
 def prepare_observation(args: argparse.Namespace, obs: Any) -> OrderedDict:
     """
     Convert a raw env observation into the model's expected input dict.
     """
     rgb_image = cv2.cvtColor(
         obs.observation["images"][CAM_KEY[args.robot_type]], cv2.COLOR_BGR2RGB)
+    if args.robot_type == 'g1_brainco':
+        # The model was trained on 12-dim ee_state (6 arm joints per arm, no hands).
+        state = _g1_brainco_qpos_to_ee_state(obs.observation["qpos"])
+    else:
+        state = obs.observation["qpos"]
     observation = {
         "observation.images.top":
         torch.from_numpy(rgb_image).permute(2, 0, 1),
         "observation.state":
-        torch.from_numpy(obs.observation["qpos"]),
+        torch.from_numpy(state),
         "action": ZERO_ACTION[args.robot_type],
     }
     return OrderedDict(observation)
@@ -111,6 +143,9 @@ def run_policy(
         # Execute the actions
         for n in range(args.exe_steps):
             action = actions[n].cpu().numpy()
+            if args.robot_type == 'g1_brainco':
+                # Model predicts 12-dim ee_action; expand to 26-dim for the robot controller.
+                action = _g1_brainco_ee_action_to_qpos(action)
             print(f">>> Exec => step {n} action: {action}", flush=True)
             print("---------------------------------------------")
 

--- a/unitree_deploy/unitree_deploy/robot/robot_configs.py
+++ b/unitree_deploy/unitree_deploy/robot/robot_configs.py
@@ -17,6 +17,7 @@ from unitree_deploy.robot_devices.cameras.configs import (
     OpenCVCameraConfig,
 )
 from unitree_deploy.robot_devices.endeffector.configs import (
+    BrancoDualHandConfig,
     Dex1_GripperConfig,
     EndEffectorConfig,
 )
@@ -155,6 +156,30 @@ def usb_camera_default_factory():
 # ======================== endeffector =================================
 
 
+def brainco_default_factory():
+    return {
+        "hands": BrancoDualHandConfig(),
+    }
+
+
+def brainco_dual_arm_default_factory(init_pose=None):
+    """G1 23-DOF arm config: no wrist pitch/yaw, forearm roll only.
+
+    The G1_29_ArmController sends commands to all 14 arm motor indices
+    (15-28). On the 23-DOF robot, indices 20-21 (left wrist pitch/yaw)
+    and 27-28 (right wrist pitch/yaw) do not exist; the SDK silently
+    ignores commands to absent joints. init_pose zeros those slots.
+    """
+    # 14 zeros: shoulder×3 + elbow + wristRoll + wristPitch(0) + wristYaw(0) per arm
+    return {
+        "g1": G1ArmConfig(
+            init_pose=np.zeros(14) if init_pose is None else init_pose,
+            motors=g1_motors,
+            mock=False,
+        ),
+    }
+
+
 def dex1_default_factory():
     return {
         "left": Dex1_GripperConfig(
@@ -268,3 +293,17 @@ class G1_Dex1_Imageclint_RobotConfig(UnitreeRobotConfig):
     cameras: dict[str, CameraConfig] = field(default_factory=g1_image_client_default_factory)
     arm: dict[str, ArmConfig] = field(default_factory=g1_dual_arm_default_factory)
     endeffector: dict[str, EndEffectorConfig] = field(default_factory=dex1_default_factory)
+
+
+# ======= Arm:g1 23-DOF, Endeffector:Brainco Revo2 dual hands, Camera:imageclient =======
+# Robot specifics:
+#   - Waist: 1 DOF (yaw/twist only, index 12)
+#   - Arms:  5 DOF each (shoulder ×3, elbow, forearm roll; NO wrist pitch/yaw)
+#   - Hands: Brainco Revo2 five-finger, USB ports /dev/ttyUSB1 (left) & /dev/ttyUSB2 (right)
+#   - Action space: 14 arm DOFs (4 phantom wrist slots kept for SDK compat) + 12 hand DOFs = 26
+@RobotConfig.register_subclass("g1_brainco")
+@dataclass
+class G1_Brainco_RobotConfig(UnitreeRobotConfig):
+    cameras: dict[str, CameraConfig] = field(default_factory=g1_image_client_default_factory)
+    arm: dict[str, ArmConfig] = field(default_factory=brainco_dual_arm_default_factory)
+    endeffector: dict[str, EndEffectorConfig] = field(default_factory=brainco_default_factory)

--- a/unitree_deploy/unitree_deploy/robot/robot_configs.py
+++ b/unitree_deploy/unitree_deploy/robot/robot_configs.py
@@ -169,11 +169,23 @@ def brainco_dual_arm_default_factory(init_pose=None):
     (15-28). On the 23-DOF robot, indices 20-21 (left wrist pitch/yaw)
     and 27-28 (right wrist pitch/yaw) do not exist; the SDK silently
     ignores commands to absent joints. init_pose zeros those slots.
+
+    init_pose matches the G1 Ready Mode arm position so go_start() does
+    not move the arms on startup (avoids conflict with env.step()).
+    Forearm roll (slots 4 and 11) is left at 0.0 — it varies freely
+    between runs and any non-zero value may cause unwanted rotation.
     """
-    # 14 zeros: shoulder×3 + elbow + wristRoll + wristPitch(0) + wristYaw(0) per arm
+    # fmt: off
+    ready_mode_pose = np.array([
+        # left:  ShPitch  ShRoll   ShYaw   Elbow   ForearmRoll  WrPitch(n/a) WrYaw(n/a)
+                  0.29,    0.13,    0.0,    0.978,  0.0,         0.0,         0.0,
+        # right: ShPitch  ShRoll   ShYaw   Elbow   ForearmRoll  WrPitch(n/a) WrYaw(n/a)
+                  0.29,   -0.13,    0.0,    0.981,  0.0,         0.0,         0.0,
+    ])
+    # fmt: on
     return {
         "g1": G1ArmConfig(
-            init_pose=np.zeros(14) if init_pose is None else init_pose,
+            init_pose=ready_mode_pose if init_pose is None else init_pose,
             motors=g1_motors,
             mock=False,
         ),

--- a/unitree_deploy/unitree_deploy/robot/robot_utils.py
+++ b/unitree_deploy/unitree_deploy/robot/robot_utils.py
@@ -1,6 +1,7 @@
 from typing import Protocol
 
 from unitree_deploy.robot.robot_configs import (
+    G1_Brainco_RobotConfig,
     G1_Dex1_Imageclint_RobotConfig,
     RobotConfig,
     Z1_Realsense_RobotConfig,
@@ -32,6 +33,8 @@ def make_robot_config(robot_type: str, **kwargs) -> RobotConfig:
         return Z1dual_Dex1_Opencv_RobotConfig(**kwargs)
     elif robot_type == "g1_dex1":
         return G1_Dex1_Imageclint_RobotConfig(**kwargs)
+    elif robot_type == "g1_brainco":
+        return G1_Brainco_RobotConfig(**kwargs)
     else:
         raise ValueError(f"Robot type '{robot_type}' is not available.")
 

--- a/unitree_deploy/unitree_deploy/robot_devices/arm/g1_arm.py
+++ b/unitree_deploy/unitree_deploy/robot_devices/arm/g1_arm.py
@@ -48,7 +48,7 @@ class G1_29_ArmController:
         self.kd_wrist = config.kd_wrist
 
         self.all_motor_q = None
-        self.q_target = np.zeros(14)
+        self.q_target = np.array(self.init_pose)  # hold init_pose until write_arm() is called
         self.dq_target = np.zeros(14)
         self.tauff_target = np.zeros(14)
         self.time_target = time.monotonic()

--- a/unitree_deploy/unitree_deploy/robot_devices/endeffector/brainco_hand.py
+++ b/unitree_deploy/unitree_deploy/robot_devices/endeffector/brainco_hand.py
@@ -1,0 +1,114 @@
+"""Brainco Revo2 dual-hand controller for unitree_deploy.
+
+Communicates with the brainco_bridge TCP server (running in the g1brainco
+ROS2 env) via newline-delimited JSON over a localhost TCP socket.
+
+Controls both hands as a single 12-DOF end-effector:
+  - positions 0–5:  left hand  (thumb, thumb_aux, index, middle, ring, pinky)
+  - positions 6–11: right hand (thumb, thumb_aux, index, middle, ring, pinky)
+  - all positions are in range 0.0 (open) to 1.0 (closed)
+
+Before connecting, start the bridge in the g1brainco env:
+    conda activate g1brainco
+    source ~/unitree_ros2/setup.sh
+    source ~/unitree-g1-brainco-hand/ros2_stark_ws/install/setup.bash
+    python ~/unifolm-world-model-action/unitree_deploy/scripts/brainco_bridge.py
+"""
+import json
+import threading
+
+import numpy as np
+
+from unitree_deploy.robot_devices.endeffector.configs import BrancoDualHandConfig
+from unitree_deploy.utils.rich_logger import log_error, log_success, log_warning
+
+
+class Brainco_DualHand_Controller:
+    JOINT_NAMES = [
+        "left_thumb", "left_thumb_aux", "left_index",
+        "left_middle", "left_ring", "left_pinky",
+        "right_thumb", "right_thumb_aux", "right_index",
+        "right_middle", "right_ring", "right_pinky",
+    ]
+
+    def __init__(self, config: BrancoDualHandConfig):
+        self.config = config
+        self.bridge_host = config.bridge_host
+        self.bridge_port = config.bridge_port
+        self.init_pose = np.array(config.init_pose) if config.init_pose else np.zeros(12)
+        self._sock = None
+        self._lock = threading.Lock()
+        self._buf = ""
+        self.is_connected = False
+
+    @property
+    def motor_names(self) -> list[str]:
+        return self.JOINT_NAMES
+
+    def connect(self):
+        import socket
+        try:
+            self._sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            self._sock.connect((self.bridge_host, self.bridge_port))
+            self._sock.settimeout(2.0)
+            self.is_connected = True
+            log_success("[Brainco_DualHand_Controller] Connected to bridge at "
+                        f"{self.bridge_host}:{self.bridge_port}")
+        except Exception as e:
+            log_error(f"❌ Brainco bridge connect failed: {e}\n"
+                      "  Make sure brainco_bridge.py is running in the g1brainco env.")
+
+    def _send_recv(self, payload: dict) -> dict:
+        with self._lock:
+            msg = json.dumps(payload) + "\n"
+            self._sock.sendall(msg.encode("utf-8"))
+            while "\n" not in self._buf:
+                chunk = self._sock.recv(1024).decode("utf-8")
+                self._buf += chunk
+            line, self._buf = self._buf.split("\n", 1)
+            return json.loads(line)
+
+    def read_current_endeffector_q(self) -> np.ndarray:
+        try:
+            resp = self._send_recv({"cmd": "get"})
+            return np.array(resp["left"] + resp["right"], dtype=np.float64)
+        except Exception as e:
+            log_warning(f"[Brainco] read error: {e}")
+            return np.zeros(12)
+
+    def read_current_endeffector_dq(self) -> np.ndarray:
+        # Brainco stark_node does not expose velocities via motor_status
+        return np.zeros(12)
+
+    def write_endeffector(
+        self,
+        q_target,
+        tauff_target=None,
+        time_target=None,
+        cmd_target=None,
+    ):
+        try:
+            positions = np.clip(np.asarray(q_target, dtype=float), 0.0, 1.0)
+            self._send_recv({
+                "cmd": "set",
+                "left": positions[:6].tolist(),
+                "right": positions[6:].tolist(),
+            })
+        except Exception as e:
+            log_warning(f"[Brainco] write error: {e}")
+
+    def go_start(self):
+        self.write_endeffector(self.init_pose)
+
+    def go_home(self):
+        # Open both hands fully
+        self.write_endeffector(np.zeros(12))
+
+    def disconnect(self):
+        self.is_connected = False
+        if self._sock:
+            try:
+                self.go_home()
+                self._sock.close()
+            except Exception:
+                pass

--- a/unitree_deploy/unitree_deploy/robot_devices/endeffector/configs.py
+++ b/unitree_deploy/unitree_deploy/robot_devices/endeffector/configs.py
@@ -27,3 +27,21 @@ class Dex1_GripperConfig(EndEffectorConfig):
     def __post_init__(self):
         if self.control_dt < 0.002:
             raise ValueError(f"`control_dt` must > 1/500 (got {self.control_dt})")
+
+
+@EndEffectorConfig.register_subclass("brainco_dual")
+@dataclass
+class BrancoDualHandConfig(EndEffectorConfig):
+    """Config for a pair of Brainco Revo2 five-finger hands controlled via
+    the brainco_bridge TCP server (see unitree_deploy/scripts/brainco_bridge.py).
+
+    USB ports: left hand -> /dev/ttyUSB1, right hand -> /dev/ttyUSB2
+    (as configured in ros2_stark_ws/src/ros2_stark_controller/config/params_v2_double.yaml)
+    """
+
+    bridge_host: str = "127.0.0.1"
+    bridge_port: int = 9877
+    # 12 DOFs total: 6 per hand (thumb, thumb_aux, index, middle, ring, pinky), range 0.0-1.0
+    num_motors: int = 12
+    init_pose: list | None = None  # 12 values; None => zeros (open hands)
+    control_dt: float = 1 / 50.0  # stark_node timer runs at 20 Hz; 50 Hz is safe

--- a/unitree_deploy/unitree_deploy/robot_devices/endeffector/utils.py
+++ b/unitree_deploy/unitree_deploy/robot_devices/endeffector/utils.py
@@ -1,6 +1,7 @@
 from typing import Protocol
 
 from unitree_deploy.robot_devices.endeffector.configs import (
+    BrancoDualHandConfig,
     Dex1_GripperConfig,
     EndEffectorConfig,
 )
@@ -32,6 +33,11 @@ def make_endeffector_motors_buses_from_configs(
             from unitree_deploy.robot_devices.endeffector.gripper import Dex1_Gripper_Controller
 
             endeffector_motors_buses[key] = Dex1_Gripper_Controller(cfg)
+
+        elif cfg.type == "brainco_dual":
+            from unitree_deploy.robot_devices.endeffector.brainco_hand import Brainco_DualHand_Controller
+
+            endeffector_motors_buses[key] = Brainco_DualHand_Controller(cfg)
 
         else:
             raise ValueError(f"The motor type '{cfg.type}' is not valid.")


### PR DESCRIPTION
## Summary

This PR consolidates all work from brownwa/unifolm-world-model-action branches `docs/brainco-setup-guide`, `docs/cyclonedds-install-fix`, and `fix/lerobot-dataset-conversion` (previously submitted as PRs #43 and #45) into a single clean branch.

### What's included

**Unitree G1 + Brainco Revo2 Five-Finger Hands support** (extends §2.1 of `unitree_deploy/README.md`):
- Architecture overview: ROS2 `stark_node` ↔ `brainco_bridge.py` TCP bridge ↔ `unitree_deploy` client
- Step-by-step setup for `g1_brainco` robot type (new `ros2_stark_ws`, `g1brainco` conda env)
- Documents G1-specific hardware: 5 real arm DOFs per arm (no wrist pitch/yaw), Brainco hand DOF layout, USB port mapping
- Fix: Terminal 1 ros2 command corrected to `ros2 launch ros2_stark_controller stark_launch.py`
- Fix: Python version constraint in `pyproject.toml` (`==3.10.18` → `>=3.10`) for robot-side install
- Fix: `libgomp` preload workaround for pinocchio on aarch64

**`g1_brainco` robot client fixes** (`unitree_deploy/scripts/robot_client.py`):
- `ZERO_ACTION` dim corrected 26→12 (matches 12-dim `ee_action` the model was trained on)
- `_g1_brainco_qpos_to_ee_state`: maps 26-DOF robot qpos → 12-dim ee_state for model conditioning
- `_g1_brainco_ee_action_to_qpos`: maps 12-dim predicted ee_action → 26-DOF qpos for robot execution
- `G1_29_ArmController` startup fixes: `q_target` initialised from `init_pose` (not zeros) to stop startup jerk; `INIT_POSE` aligned to G1 Ready Mode arm position

**CycloneDDS install fix** (`unitree_deploy/README.md` Troubleshooting section):
- Documents `CYCLONEDDS_HOME` export needed before `pip install -e .` on Unitree G1

**LeRobot v3 → unifolm-wma dataset conversion** (`scripts/prepare_lerobot_dataset.py`):
- HuggingFace datasets from unitreerobotics are published in LeRobot v3.0 parquet format; `WMAData` expects a different layout (CSV + H5 transitions + per-episode videos)
- One-time conversion script produces the exact directory layout `DataModuleFromConfig.setup()` requires
- Supports `--camera_key`, `--action_key`, `--state_key`, `--instruction` flags for any dataset

**NVIDIA DGX Spark / Blackwell GPU support** (`SPARK_SETUP.md`, `real_eval_server.py`, model code):
- SDPA fallback for xformers on Blackwell architecture
- Replaced deprecated torchvision video I/O with imageio
- Added `SPARK_SETUP.md` with full DGX Spark environment setup

## Test plan

- [ ] Follow `unitree_deploy/README.md §2.1` on a G1 + Brainco Revo2 — confirm stark_node connects via `ros2 launch ros2_stark_controller stark_launch.py`
- [ ] Run `python scripts/prepare_lerobot_dataset.py --dataset_dir ~/.cache/.../G1_WBT_Brainco_Pickup_Pillow/snapshots/<hash> --dataset_name G1_WBT_Brainco_Pickup_Pillow` — confirm `WMAData` loads 300 samples
- [ ] Start `real_eval_server.py` on DGX Spark — confirm server starts and serves on NVIDIA B200

## Related issues

Closes #46 (partial — the domain-gap / inference quality issues are upstream model limitations, not setup issues)

🤖 Generated with [Claude Code](https://claude.com/claude-code)